### PR TITLE
feat: Badge 컴포넌트 구현

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run format && git add .
+npm run format

--- a/src/app/_component/common/Badge/Badge.variants.tsx
+++ b/src/app/_component/common/Badge/Badge.variants.tsx
@@ -1,0 +1,30 @@
+import { cva } from "class-variance-authority";
+
+export const BadgeVariants = cva(
+  "absolute text-sm inline-flex justify-center items-center rounded-full",
+  {
+    variants: {
+      position: {
+        "top-left": "left-0 top-[5%] -translate-x-1/2 -translate-y-1/2",
+        "top-right": "right-0 top-[5%] translate-x-1/2 -translate-y-1/2",
+        "bottom-left": "bottom-[5%] left-0 -translate-x-1/2 translate-y-1/2",
+        "bottom-right": "bottom-[5%] right-0 translate-x-1/2 translate-y-1/2"
+      },
+      size: {
+        xs: "h-2 w-2 text-xs",
+        sm: "h-3 w-3 text-xs",
+        md: "w-auto min-w-5 px-[2px]",
+        lg: "w-auto min-w-6 py-[2px]"
+      },
+      badgeType: {
+        icon: "",
+        number: "bg-[#96E4FF] text-white"
+      }
+    },
+    defaultVariants: {
+      position: "top-right",
+      size: "lg",
+      badgeType: "number"
+    }
+  }
+);

--- a/src/app/_component/common/Badge/index.tsx
+++ b/src/app/_component/common/Badge/index.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/utils/cn";
+import { VariantProps, cva } from "class-variance-authority";
+
+interface Props extends VariantProps<typeof BadgeVariants> {
+  children: React.ReactElement;
+  content?: React.ReactElement;
+  maxCount?: number;
+}
+
+function Badge({
+  children,
+  badgeType,
+  content,
+  position,
+  size,
+  maxCount
+}: Props) {
+  return (
+    <div className="relative inline-block">
+      {children}
+      <span className={cn(BadgeVariants({ position, size, badgeType }))}>
+        {typeof content === "number" && maxCount && content > maxCount
+          ? `${maxCount}+`
+          : content}
+      </span>
+    </div>
+  );
+}
+
+export default Badge;
+
+export const BadgeVariants = cva(
+  "absolute text-sm inline-flex justify-center items-center rounded-full",
+  {
+    variants: {
+      position: {
+        "top-left": "left-0 top-[5%] -translate-x-1/2 -translate-y-1/2",
+        "top-right": "right-0 top-[5%] translate-x-1/2 -translate-y-1/2",
+        "bottom-left": "bottom-[5%] left-0 -translate-x-1/2 translate-y-1/2",
+        "bottom-right": "bottom-[5%] right-0 translate-x-1/2 translate-y-1/2"
+      },
+      size: {
+        xs: "h-2 w-2 text-xs",
+        sm: "h-3 w-3 text-xs",
+        md: "w-auto min-w-5 px-[2px]",
+        lg: "w-auto min-w-6 py-[2px]"
+      },
+      badgeType: {
+        icon: "",
+        number: "bg-[#96E4FF] text-white"
+      }
+    },
+    defaultVariants: {
+      position: "top-right",
+      size: "lg",
+      badgeType: "number"
+    }
+  }
+);

--- a/src/app/_component/common/Badge/index.tsx
+++ b/src/app/_component/common/Badge/index.tsx
@@ -1,26 +1,40 @@
 import { cn } from "@/utils/cn";
-import { VariantProps, cva } from "class-variance-authority";
+import { VariantProps } from "class-variance-authority";
+import { BadgeVariants } from "./Badge.variants";
 
 interface BadgeProps extends VariantProps<typeof BadgeVariants> {
-  children: React.ReactElement;
-  content?: React.ReactElement;
+  children: React.ReactNode;
+  content?: React.ReactNode;
   maxCount?: number;
+  className?: string;
 }
 
 const Badge = ({
   position,
   size,
+  badgeType,
+  children,
+  content,
+  maxCount,
+  className,
+  ...props
 }: BadgeProps) => {
+  const badgeContent =
+    typeof content === "number" && maxCount && content > maxCount
+      ? `${maxCount}+`
+      : content;
+
   return (
-    <div className="relative inline-block">
+    <div
+      className="relative inline-block"
+      {...props}>
       {children}
-      <span className={cn(BadgeVariants({ position, size, badgeType }))}>
-        {typeof content === "number" && maxCount && content > maxCount
-          ? `${maxCount}+`
-          : content}
+      <span
+        className={cn(BadgeVariants({ position, size, badgeType }), className)}>
+        {badgeContent}
       </span>
     </div>
   );
-}
+};
 
 export default Badge;

--- a/src/app/_component/common/Badge/index.tsx
+++ b/src/app/_component/common/Badge/index.tsx
@@ -28,32 +28,3 @@ function Badge({
 }
 
 export default Badge;
-
-export const BadgeVariants = cva(
-  "absolute text-sm inline-flex justify-center items-center rounded-full",
-  {
-    variants: {
-      position: {
-        "top-left": "left-0 top-[5%] -translate-x-1/2 -translate-y-1/2",
-        "top-right": "right-0 top-[5%] translate-x-1/2 -translate-y-1/2",
-        "bottom-left": "bottom-[5%] left-0 -translate-x-1/2 translate-y-1/2",
-        "bottom-right": "bottom-[5%] right-0 translate-x-1/2 translate-y-1/2"
-      },
-      size: {
-        xs: "h-2 w-2 text-xs",
-        sm: "h-3 w-3 text-xs",
-        md: "w-auto min-w-5 px-[2px]",
-        lg: "w-auto min-w-6 py-[2px]"
-      },
-      badgeType: {
-        icon: "",
-        number: "bg-[#96E4FF] text-white"
-      }
-    },
-    defaultVariants: {
-      position: "top-right",
-      size: "lg",
-      badgeType: "number"
-    }
-  }
-);

--- a/src/app/_component/common/Badge/index.tsx
+++ b/src/app/_component/common/Badge/index.tsx
@@ -1,20 +1,16 @@
 import { cn } from "@/utils/cn";
 import { VariantProps, cva } from "class-variance-authority";
 
-interface Props extends VariantProps<typeof BadgeVariants> {
+interface BadgeProps extends VariantProps<typeof BadgeVariants> {
   children: React.ReactElement;
   content?: React.ReactElement;
   maxCount?: number;
 }
 
-function Badge({
-  children,
-  badgeType,
-  content,
+const Badge = ({
   position,
   size,
-  maxCount
-}: Props) {
+}: BadgeProps) => {
   return (
     <div className="relative inline-block">
       {children}


### PR DESCRIPTION
## 📑 구현 사항

아이콘 및 아바타에 사용할 badge 컴포넌트 구현했습니다.

- `content`에 값을 넣지않은 경우 online 아이콘으로 사용 가능합니다. (사진 중 xs 예시)
- `content`가 `maxCount`보다 클 경우 `maxCount+` 로 출력됩니다.
- `badgeType`의 기본값은 `number`로 배경색이 있고, `icon`은 배경색이 적용되지않습니다.
- top-right, top-left, bottom-right, bottom-left로 원하는 위치에 출력할 수 있습니다.
- badge의 사이즈를 설정할 수 있습니다.  (xs, sm, md, lg)

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/d4c01746-667a-4e81-ba2b-af65947bf3f2)

## 🚧 특이 사항

### 정하면 좋을 내용

1. ReactNode, ReactElement 중 어떤 타입을 사용할까요? 
2. variants를 파일 분리해서 관리하는게 좋을까요? 아니면 컴포넌트 파일 안에서 관리하는게 좋을까요?

[기타]
- husky 관련 수정했습니다! 

</br>

## 🚨관련 이슈

#16 

---
## 코드 리뷰 반영 사항

- [x]  cva 파일 분리 (badge.variants.ts)
- [x]  함수 표현식으로 변경
- [x]  interface props명 변경
- [x]  props, classname 타입 추가

### ReactNode vs ReactElement

기존 `content`의 타입을 `ReactElement`로 설정했는데, `content`가 `number`일 때 다음과 같은 오류가 발생했습니다. 

> Type 'number' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
> 

타입을 찾아보니 **ReactElement는** string, number, undefined를 전달하면 오류가 발생하는 것을 알았습니다. 

```tsx
interface ReactElement<
        P = any,
        T extends string | JSXElementConstructor<any> = string | JSXElementConstructor<any>,
    > {
        type: T;
        props: P;
        key: string | null;
    }
```

**따라서** React가 렌더링 할 수 있는 모든 것을 허용하는 ReactNode를 사용했습니다.

```tsx
type ReactNode =
        | ReactElement
        | string
        | number
        | Iterable<ReactNode>
        | ReactPortal
        | boolean
        | null
        | undefined
        | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[
            keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES
        ];
```

[React.ReactNode vs  React.ReactElement 참고사이트](https://www.totaltypescript.com/jsx-element-vs-react-reactnode)

- 오늘 정한 컨벤션을 지키려 노력했는데, 제가 빠뜨린 부분 있으면 말씀해주세요!