### PR TITLE
feat: skeleton 컴포넌트 구현

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "endOfLine": "lf",
+  "singleAttributePerLine": true,
+  "bracketSameLine": true,
+  "trailingComma": "none"
+}

--- a/src/app/_component/common/Skeleton/Paragraph.tsx
+++ b/src/app/_component/common/Skeleton/Paragraph.tsx
@@ -1,0 +1,27 @@
+import Skeleton from ".";
+
+function Paragraph({ line = 3 }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from(Array(line), (_, index) =>
+        index !== line - 1 ? (
+          <Skeleton
+            key={index}
+            width="w-full"
+            height="h-11"
+            round="rounded-md"
+          />
+        ) : (
+          <Skeleton
+            key={index}
+            width="w-7/12"
+            height="h-11"
+            round="rounded-md"
+          />
+        )
+      )}
+    </div>
+  );
+}
+
+export default Paragraph;

--- a/src/app/_component/common/Skeleton/index.tsx
+++ b/src/app/_component/common/Skeleton/index.tsx
@@ -1,0 +1,17 @@
+type WidthType = `w-${string}` | `w-${number}`;
+type HeightType = `h-${string}` | `h-${number}`;
+
+interface Props {
+  width: WidthType;
+  height: HeightType;
+  round: "rounded-full" | "rounded-md";
+}
+
+function Skeleton({ width, height, round }: Props) {
+  return (
+    <div
+      className={`${width} ${height} ${round} animate-pulse bg-gray-300`}></div>
+  );
+}
+
+export default Skeleton;


### PR DESCRIPTION
## 📑 구현 사항

Skeleton 컴포넌트 구현

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/48312988-9e6a-4cd0-acb7-00bd6778f1d9


- paragraph를 제외한 원형과 사각형은 Skeleton 컴포넌트를 사용합니다.
- props로 width, height, round를 사용합니다.

<br/>

## 🚧 특이 사항

- width, height를 동적으로 받기때문에 다음과 같이 타입 정의를 했습니다. 
이렇게 타입 지정 하는 것이 좋을까요?

```
type WidthType = `w-${string}` | `w-${number}`;
type HeightType = `h-${string}` | `h-${number}`;

interface Props {
  width: WidthType;
  height: HeightType;
  round: "rounded-full" | "rounded-md";
}
```

skeleton을 공통 컴포넌트로 처음 구현해봤는데 관련해서 더 좋은 아이디어 공유해주시면 반영하겠습니다ㅎㅎ

[기타]
- [jsxBracketSameLine](https://prettier.io/blog/2021/09/09/2.4.0.html#:~:text=This%20release%20renames%20the%20jsxBracketSameLine,such%20as%20class%20static%20blocks)을 `bracketSameLine`으로 수정했습니다! 

</br>

## 🚨관련 이슈

#17 