### PR TITLE
feat: geolocation을 이용한 사용자 현재 위치 구현

### DIFF
--- a/src/app/hooks/useGeolocation.ts
+++ b/src/app/hooks/useGeolocation.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+export interface GeolocationType {
+  latitude: number;
+  longitude: number;
+}
+
+interface GeolocationError {
+  code: number;
+  message: string;
+}
+
+const options = {
+  timeout: 7000,
+  maximumAge: 6000,
+};
+
+const useGeolocation = () => {
+  const [geoLocation, setGeoLocation] = useState<GeolocationType>();
+  const [error, setError] = useState<GeolocationError>();
+
+  const handleGeolocationSuccess = (position: GeolocationPosition) => {
+    const { latitude, longitude } = position.coords;
+
+    setGeoLocation({
+      latitude,
+      longitude,
+    });
+  };
+
+  const handleGeolocationError = (err: GeolocationError) => {
+    const { code, message } = err;
+
+    setError({ code, message });
+  };
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.permissions.query({ name: "geolocation" }).then((result) => {
+        if (result.state === "granted" || result.state === "prompt") {
+          navigator.geolocation.getCurrentPosition(
+            handleGeolocationSuccess,
+            handleGeolocationError,
+            options,
+          );
+        } else if (result.state === "denied") {
+          setError({
+            code: -1,
+            message: "정확한 위치 확인을 위해 위치 정보 사용을 허용해 주세요.",
+          });
+        }
+      });
+    } else {
+      setError({
+        code: -1,
+        message:
+          "현재 브라우저에서는 위치 정보를 제공할 수 없어요. 다시 시도해주세요.",
+      });
+    }
+  }, []);
+
+  return { geoLocation, error };
+};
+
+export default useGeolocation;


### PR DESCRIPTION
## 📑 구현 사항
- geolocation을 이용한 사용자 현재 위치를 받아오는 hook을 구현

## 🚧 특이 사항
### navigator permission의 3가지 상태에 따라 구현

1. **granted**: 위치 정보에 액세스 할 수 있는 권한이 있으므로 geolocation을 호출할 수 있음
2. **prompt**: 사용자에게 권한을 요청하는 팝업을 표시
3. **denied**: 사용자가 위치 공유를 거부했음을 의미

> 사용자가 이미 위치 권한을 거부한 경우 사용자가 브라우저에서 수동으로 위치 권한을 활성화하지 않는 한 다시 위치 권한을 묻는 메세지를 표시할 수 있는 방법은 없습니다.


### 사용자 위치를 받아올 수 없는 경우 어떻게 하지? 
[회의 내용] 
1. 사용자 위치를 어떤 상황에서 사용할지에 대한 설명
2. 알림창으로 사용자 위치 사용 동의하지않을 경우 회원가입 및 사이트 이용 불가!


## 📃 참고 자료




## 🚨 관련 이슈

#36 

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
