### PR TITLE
feat: Avatar 컴포넌트 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    unoptimized: true,
+  },
+};
 
 export default nextConfig;

--- a/src/app/_component/common/Avatar/Avatar.variants.ts
+++ b/src/app/_component/common/Avatar/Avatar.variants.ts
@@ -1,0 +1,22 @@
+import { cva } from "class-variance-authority";
+
+export const AvatarVariants = cva(
+  "relative overflow-hidden",
+  {
+    variants: {
+      size: {
+        small: "w-8 h-8",
+        medium: "w-12 h-12",
+        large: "w-24 h-24",
+      },
+      rounded: {
+        none: "rounded-md",
+        full: "rounded-full",
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+      rounded: "none",
+    }
+  }
+);

--- a/src/app/_component/common/Avatar/index.tsx
+++ b/src/app/_component/common/Avatar/index.tsx
@@ -1,7 +1,8 @@
 import { cn } from "@/utils/cn";
-import { VariantProps, cva } from "class-variance-authority";
+import { VariantProps } from "class-variance-authority";
 import Image from "next/image";
 import { ImgHTMLAttributes } from "react";
+import { AvatarVariants } from "./Avatar.variants";
 
 interface Props extends VariantProps<typeof AvatarVariants>, Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "width" | "height"> {
   src: string;
@@ -9,7 +10,7 @@ interface Props extends VariantProps<typeof AvatarVariants>, Omit<ImgHTMLAttribu
 
 function Avatar({ size, rounded, src, ...props }: Props) {
   return (
-    <div className={cn(AvatarVariants({ size, rounded }), rounded ? "rounded-full" : "rounded-md")}>
+    <div className={cn(AvatarVariants({ size, rounded }))}>
       <Image
         alt={props.alt || ""}
         src={src}
@@ -23,24 +24,3 @@ function Avatar({ size, rounded, src, ...props }: Props) {
 }
 
 export default Avatar;
-
-export const AvatarVariants = cva(
-  "relative overflow-hidden",
-  {
-    variants: {
-      size: {
-        small: "w-8 h-8",
-        medium: "w-12 h-12",
-        large: "w-24 h-24",
-      },
-      rounded: {
-        none: "rounded-md",
-        full: "rounded-full",
-      },
-    },
-    defaultVariants: {
-      size: "medium",
-      rounded: "none",
-    }
-  }
-);

--- a/src/app/_component/common/Avatar/index.tsx
+++ b/src/app/_component/common/Avatar/index.tsx
@@ -8,7 +8,7 @@ interface Props extends VariantProps<typeof AvatarVariants>, Omit<ImgHTMLAttribu
   src: string;
 }
 
-function Avatar({ size, rounded, src, ...props }: Props) {
+const Avatar = ({ size, rounded, src, ...props }: Props) => {
   return (
     <div className={cn(AvatarVariants({ size, rounded }))}>
       <Image
@@ -21,6 +21,6 @@ function Avatar({ size, rounded, src, ...props }: Props) {
       />
     </div>
   );
-}
+};
 
 export default Avatar;

--- a/src/app/_component/common/Avatar/index.tsx
+++ b/src/app/_component/common/Avatar/index.tsx
@@ -9,10 +9,10 @@ interface Props extends VariantProps<typeof AvatarVariants>, Omit<ImgHTMLAttribu
 
 function Avatar({ size, rounded, src, ...props }: Props) {
   return (
-    <div className={cn(AvatarVariants({ size, rounded }))}>
+    <div className={cn(AvatarVariants({ size, rounded }), rounded ? "rounded-full" : "rounded-md")}>
       <Image
         alt={props.alt || ""}
-        src="/images1.webp"
+        src={src}
         width={100}
         height={100}
         className="w-full h-full object-cover"
@@ -40,7 +40,7 @@ export const AvatarVariants = cva(
     },
     defaultVariants: {
       size: "medium",
-      rounded: "full",
+      rounded: "none",
     }
   }
 );

--- a/src/app/_component/common/Avatar/index.tsx
+++ b/src/app/_component/common/Avatar/index.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/utils/cn";
+import { VariantProps, cva } from "class-variance-authority";
+import Image from "next/image";
+import { ImgHTMLAttributes } from "react";
+
+interface Props extends VariantProps<typeof AvatarVariants>, Omit<ImgHTMLAttributes<HTMLImageElement>, "src" | "width" | "height"> {
+  src: string;
+}
+
+function Avatar({ size, rounded, src, ...props }: Props) {
+  return (
+    <div className={cn(AvatarVariants({ size, rounded }))}>
+      <Image
+        alt={props.alt || ""}
+        src="/images1.webp"
+        width={100}
+        height={100}
+        className="w-full h-full object-cover"
+        {...props}
+      />
+    </div>
+  );
+}
+
+export default Avatar;
+
+export const AvatarVariants = cva(
+  "relative overflow-hidden",
+  {
+    variants: {
+      size: {
+        small: "w-8 h-8",
+        medium: "w-12 h-12",
+        large: "w-24 h-24",
+      },
+      rounded: {
+        none: "rounded-md",
+        full: "rounded-full",
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+      rounded: "full",
+    }
+  }
+);


### PR DESCRIPTION
## 📑 구현 사항

- [x] 이미지 반영
- [x] 원형, 사각형 지원
사각형은 최대한 범용성있게 사용하고자 추가했습니다.

## 🚧 특이 사항

- Next 특성상 허용된 이미지 경로가 아니면 오류를 반환하는 경우가 발생합니다.
`next.config.mjs` 에서 경로 추가하면 되는데 현재 아바타 이미지가 어디서 오는지 확정되지 않아 형식만 추가해둡니다.

``` mjs
/** @type {import('next').NextConfig} */
const nextConfig = {
  images: { // 이미지 추가
    domains: ["cdn.pixabay.com"], // 예시 이미지는 pixabay에서 가져와 이렇게 처리
  },
};

export default nextConfig;

```
- 크기 조절
small, medium, large 3가지의 임의 크기로 지정했는데, 가입시 이미지 추가할 때 어현재 large의 크기를 넘길 수 있을 것 같아 수정이 필요할 것 같습니다.
(아래 참고 사진이 현재 가장 크게 아바타가 사용되는 영역)
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/104545906/9e891e4b-1007-46bd-8483-3845007554e1)

UI구현시 최대한 large는 배제하고 사용하시는 것을 권장드립니다.

## 📃 참고 자료
- 사각형 이미지 (참고 예시)
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/104545906/210e73eb-7250-4ee9-ac80-90481e03a409)
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/104545906/d0ec9417-98d4-4758-80cc-3407fa663fcc)

- 원형 이미지 (기본 아바타에 들어갈 형식)
`<Avatar src="https://cdn.pixabay.com/photo/2024/01/18/12/54/flowers-8516916_1280.jpg" rounded />` rounded 추가시 원형
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/104545906/f92bd548-241c-422a-89d5-6e2f04db686b)

## 🚨 관련 이슈

close #12 

## ✅ 리뷰 반영 사항

- [x] unoptimized 속성 추가
- [ ] blur는 훗날 처리 (아바타 보다 이미지에서 필요한 속성으로 파악, 차후 최적화 시점에서 필요시 다시 고려)