### PR TITLE
feat: 매너 온도 컴포넌트 구현

### DIFF
--- a/src/app/_component/common/Reliabilitybar/Reliability.variants.ts
+++ b/src/app/_component/common/Reliabilitybar/Reliability.variants.ts
@@ -1,0 +1,28 @@
+import { cva } from "class-variance-authority";
+
+export const ThemeVariants = cva(
+  "w-full border h-full animate-fill rounded-full",
+  {
+    variants: {
+      theme: {
+        default: "bg-[#96E4FF]",
+        terrible: "bg-purple-400",
+        poor: "bg-red-400",
+        main: "bg-sky-400",
+        good: "bg-blue-400",
+      },
+    },
+  }
+);
+
+export const TextVariants = cva("text-sm", {
+  variants: {
+    theme: {
+      default: "text-[#96E4FF]",
+      terrible: "text-purple-400 absolute left-10",
+      poor: "text-red-400 absolute left-10",
+      main: "text-sky-400 absolute right-10",
+      good: "text-blue-400 absolute right-10",
+    },
+  },
+});

--- a/src/app/_component/common/Reliabilitybar/index.tsx
+++ b/src/app/_component/common/Reliabilitybar/index.tsx
@@ -1,0 +1,24 @@
+function ReliabilityBar({ score = 100 }) {
+  const width = Math.floor(score / 2);
+  const text = score === 100 ? "첫 매너 100%" : `${score}% 선해요`;
+
+  return (
+    <div>
+      <div className="flex justify-between p-2">
+        <span>😈</span>
+        <span className="text-sm text-gray-600">{text}</span>
+        <span>😇</span>
+      </div>
+
+      <div className="relative w-full h-3 rounded-full bg-[#96E4FF] z-10">
+        <div
+          className="absolute h-3 z-100"
+          style={{ width: `${width}%` }}>
+          <div className="w-full bg-white border border-[#96E4FF] h-full animate-fill rounded-full"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ReliabilityBar;

--- a/src/app/_component/common/Reliabilitybar/index.tsx
+++ b/src/app/_component/common/Reliabilitybar/index.tsx
@@ -1,20 +1,37 @@
+import { cn } from "@/utils/cn";
+import { TextVariants, ThemeVariants } from "./Reliability.variants";
+
+type Theme = "default" | "main" | "terrible" | "poor" | "good";
+
 function ReliabilityBar({ score = 100 }) {
   const width = Math.floor(score / 2);
   const text = score === 100 ? "첫 매너 100%" : `${score}% 선해요`;
+
+  let theme: Theme = "default";
+
+  if (score >= 0 && score < 50) {
+    theme = "terrible";
+  } else if (score < 100) {
+    theme = "poor";
+  } else if (score === 100) {
+    theme = "default";
+  } else if (score < 150) {
+    theme = "main";
+  } else if (score < 200) {
+    theme = "good";
+  }
 
   return (
     <div>
       <div className="flex justify-between p-2">
         <span>😈</span>
-        <span className="text-sm text-gray-600">{text}</span>
+        <span className={cn(TextVariants({ theme }))}>{text}</span>
         <span>😇</span>
       </div>
 
-      <div className="relative w-full h-3 rounded-full bg-[#96E4FF] z-10">
-        <div
-          className="absolute h-3 z-100"
-          style={{ width: `${width}%` }}>
-          <div className="w-full bg-white border border-[#96E4FF] h-full animate-fill rounded-full"></div>
+      <div className="relative w-full h-3 rounded-full bg-gray-100 z-10">
+        <div className="absolute h-3 z-100" style={{ width: `${width}%` }}>
+          <div className={cn(ThemeVariants({ theme }))}></div>
         </div>
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,14 @@
       opacity: 0;
     }
   }
+  @keyframes fill {
+    from {
+      width: 0%;
+    }
+    to {
+      width: 100%;
+    }
+  }
 }
 
 @layer utilities {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,7 +4,7 @@ const config: Config = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   darkMode: "class",
   theme: {
@@ -12,7 +12,7 @@ const config: Config = {
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))"
       },
       animation: {
         beat: "beat linear 0.5s forwards",
@@ -20,12 +20,13 @@ const config: Config = {
         progress: "progress linear forwards 0.4s",
         rightMove: "rightMove ease forwards 0.4s ",
         leftMove: "leftMove ease forwards 0.4s ",
+        fill: "fill 1s linear forwards"
       },
       fontFamily: {
-        sans: ["Yeongdeok"],
-      },
-    },
+        sans: ["Yeongdeok"]
+      }
+    }
   },
-  plugins: [],
+  plugins: []
 };
 export default config;


### PR DESCRIPTION
## 📑 구현 사항

- 사용자 정보에서 사용 할 매너 온도 컴포넌트 구현 


## 🚧 특이 사항

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/0cde3f73-0f51-45b1-b814-c42cc77b8f90)

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/259c02a7-8851-4e72-addc-36eaff0cdc4c)

악하다는 표현이 좋지않아 **50%악해요**가 아닌 **50%선해요**로 표현했습니다!
또 100점에서 27점 깎인 점수인데, 너무 악해보여(?) 73%선해요로 출력됩니다 : )

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/1b917a17-85c4-4fdb-a922-23774f4d53b3)

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/d5fa6791-73d3-4f7f-b042-4dc622e0f2c2)

137%는 높은 점수인데 시각적으로 잘 들어오지 않고, 전체 선해요로 변경하며 막대기가 처음부터 시작하는게 좋을 것 같아 다음과 같이 변경했습니다. 

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/895b51cf-490e-42be-a139-40ab5e3d7ff4)

![스크린샷 2024-02-15 오전 10 15 49](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/1cdb76ca-6eec-4aef-90d3-c2d5285d6b7e)


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #46 

## ✅ 리뷰 반영 사항

당근처럼 매너 점수에 따라 색상 변경 적용했습니다! 

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/6e7b9184-0804-481b-862b-72dbf69687dc

