### PR TITLE
feat: 채팅 메세지 컴포넌트 구현

### DIFF
--- a/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
+++ b/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
@@ -1,12 +1,12 @@
 import { cva } from "class-variance-authority";
 
 export const ChatMessageVariants = cva(
-  "px-4 py-2 my-1 max-w-56 whitespace-pre-line",
+  "px-4 py-2 mt-2 max-w-56 whitespace-pre-line",
   {
     variants: {
       sender: {
         me: "bg-[#96E4FF] rounded-l-3xl rounded-br-2xl hover:bg-[#96E4FF]/50 self-end",
-        you: "bg-[#D9D9D9] rounded-r-3xl rounded-bl-2xl hover:bg-[#D9D9D9]/50 self-start",
+        you: "bg-[#D9D9D9] ml-14 rounded-r-3xl rounded-bl-2xl hover:bg-[#D9D9D9]/50 self-start",
       }
     },
     defaultVariants: {

--- a/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
+++ b/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const ChatMessageVariants = cva(
-  "items-start justify-start px-4 py-2 m-1 max-w-56",
+  "px-4 py-2 my-1 max-w-56 whitespace-pre-line",
   {
     variants: {
       sender: {

--- a/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
+++ b/src/app/_component/common/ChatMessage/Chatmessage.variants.ts
@@ -1,0 +1,16 @@
+import { cva } from "class-variance-authority";
+
+export const ChatMessageVariants = cva(
+  "items-start justify-start px-4 py-2 m-1 max-w-56",
+  {
+    variants: {
+      sender: {
+        me: "bg-[#96E4FF] rounded-l-3xl rounded-br-2xl hover:bg-[#96E4FF]/50 self-end",
+        you: "bg-[#D9D9D9] rounded-r-3xl rounded-bl-2xl hover:bg-[#D9D9D9]/50 self-start",
+      }
+    },
+    defaultVariants: {
+      sender: "me"
+    }
+  }
+);

--- a/src/app/_component/common/ChatMessage/index.tsx
+++ b/src/app/_component/common/ChatMessage/index.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/utils/cn";
+import { ChatMessageVariants } from "./Chatmessage.variants";
+import { VariantProps } from "class-variance-authority";
+
+interface Props extends VariantProps<typeof ChatMessageVariants> {
+  avatar?: string;
+  message: string;
+  sender: "me" | "you";
+}
+
+const ChatMessage = ({ avatar, message, sender, ...props }: Props) => {
+  return (
+    <div className={cn(ChatMessageVariants({ sender }))} {...props}>
+      {avatar && <img src={avatar} alt="Avatar" className="mr-2" />}
+      <span>{message}</span>
+    </div>
+  );
+};
+
+export default ChatMessage;

--- a/src/app/_component/common/ChatMessage/index.tsx
+++ b/src/app/_component/common/ChatMessage/index.tsx
@@ -1,19 +1,35 @@
 import { cn } from "@/utils/cn";
 import { ChatMessageVariants } from "./Chatmessage.variants";
 import { VariantProps } from "class-variance-authority";
+import Avatar from "../Avatar";
 
 interface Props extends VariantProps<typeof ChatMessageVariants> {
-  avatar?: string;
+  avatar: string;
   message: string;
   sender: "me" | "you";
+  previousSender: "me" | "you" | null;
 }
 
-const ChatMessage = ({ avatar, message, sender, ...props }: Props) => {
+const ChatMessage = ({
+  avatar,
+  message,
+  sender,
+  previousSender,
+  ...props
+}: Props) => {
   return (
-    <div className={cn(ChatMessageVariants({ sender }))} {...props}>
-      {avatar && <img src={avatar} alt="Avatar" className="mr-2" />}
-      <span>{message}</span>
-    </div>
+    <>
+      <div {...props} className='flex flex-col'>
+        <div className='absolute'>
+          {sender === "you" && previousSender !== "you" && (
+            <Avatar src={avatar} alt='Avatar' rounded='full' />
+          )}
+        </div>
+        <div className={cn(ChatMessageVariants({ sender }))}>
+          <span>{message}</span>
+        </div>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📑 구현 사항

- [x] 메세지 줄바꿈 대응
- [x] 상대방 아바타 표현
- [x] 상대 연속 메세지 아바타 중복 제거
- [x] 전송자별 레이아웃 구분

## 🚧 특이 사항
- 신고 기능 도입 가능성이 있어 hover 적용

### 데이터 수신 방식
- 현재 웹소켓에서 채팅 데이터의 정확한 저장법을 알 수 없어 임의로 작성되어 있습니다.
```ts
const mockData = [
  {
    idx: 1,
    id: "you",
    data: "상대방 메세지"
  },
  {
    idx: 2,
    id: "you",
    data: "상대방의 연속적인 메세지"
  },
  {
    idx: 3,
    id: "me",
    data: "내 메세지"
  },
  {
    idx: 4,
    id: "you",
    data: "상대의 새로운 메세지 긴 메세지는 어느정도 까지 길어지면 다음 줄로 넘어가게!"
  },
  {
    idx: 5,
    id: "me",
    data: "내 새로운 메시지"
  },
  {
    idx: 6,
    id: "me",
    data: `나의 긴 메세지.
    강제로 줄바꿈하면?
    이런식으로 나오도록, 서버에 줄바꿈도 저장되나?`
  },
];
```
차후 정확한 값이 나오면 데이터 연결 관련 추가 수정이 필요한 상황입니다.
```ts
export default function Home() {
  return <main className="flex flex-col">
  {mockData.map((i, idx) => (
    <ChatMessage 
      avatar={avatarSrc}
      key={i.idx} 
      message={i.data} 
      sender={i.id === "me" ? "me" : "you"} 
      previousSender={idx > 0 ? mockData[idx - 1].id : null}
    />
  ))}
</main>;
}
```

![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/104545906/5baaa016-f3c2-4c30-acac-054d79fde20e)


### 차후 수정 사항
\* 디자인적 수정보다 기능적 to-be 요소
채팅 값이 배열 형식일 경우 map으로 예시와 같이 동작 가능

- me/you는 유저 정보를 받아와 본인인지 확인하는 필터 필요
한번 필터링을 할지, userId값을 비교할지 등등
- previousSender는 null값으로 현재 에러를 띄우나 정상적으로 동작중 실제 데이터 연결시에는 타입 검사 다시 확인
- key가 타임스템프일지 인덱스 값일지 확인 필요
- data는 ERD내 content와 동일한 값

## 🚨 관련 이슈

close #50 

<!-- ## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성 -->
