### PR TITLE
refactor: className 커스텀 기능 추가

### DIFF
--- a/src/app/hooks/useModal/index.tsx
+++ b/src/app/hooks/useModal/index.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/utils/cn";
 import useClickAway from "../useClickAway";
 import { modalTypeVariants } from "./ModalType.variants";
 import { VariantProps } from "class-variance-authority";
+import { ModalContentProps, UseModalResult } from "./type";
 
 interface useModalParams extends VariantProps<typeof modalTypeVariants> {
   initialValue?: boolean;
@@ -14,14 +15,6 @@ interface useModalParams extends VariantProps<typeof modalTypeVariants> {
   elementId?: string;
   modalType?: "default" | "dropBox" | "fullScreen";
   animate?: "grow" | "slide";
-  className?: string;
-}
-
-export interface UseModalResult {
-  Modal: ({ children }: { children: ReactNode }) => JSX.Element;
-  open: () => void;
-  close: () => void;
-  isOpen: boolean;
 }
 
 const animateIn = {
@@ -39,8 +32,7 @@ const useModal = ({
   height = 100,
   modalType = "default",
   elementId = "global-modal",
-  animate = "grow",
-  className
+  animate = "grow"
 }: useModalParams): UseModalResult => {
   const [isOpen, setOpen] = useState<boolean>(initialValue);
   const [isUnmount, setIsUnmount] = useState(false);
@@ -60,7 +52,7 @@ const useModal = ({
     }, 300);
   }, [setOpen]);
 
-  const Modal = ({ children }: { children: ReactNode }) => {
+  const Modal = ({ children, className }: ModalContentProps) => {
     const ModalContent = ({ children }: { children: ReactNode }) => {
       const ref = useClickAway<HTMLDivElement>(() => {
         close();

--- a/src/app/hooks/useModal/type.ts
+++ b/src/app/hooks/useModal/type.ts
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+
+export interface UseModalResult {
+  Modal: ({ children, className }: ModalContentProps) => JSX.Element;
+  open: () => void;
+  close: () => void;
+  isOpen: boolean;
+}
+
+export interface ModalContentProps {
+  children: ReactNode;
+  className?: string;
+}


### PR DESCRIPTION
## 📑 구현 사항

- [x] useModal의 Modal 컴포넌트에 className 설정 기능 추가


## 🚧 특이 사항

- 사용방법
```
   <Modal className="dark:bg-gray-400"> //className으로 커스텀 가능
        <ul
          className="text-black"
          onClick={handleClickStore}>
          <li id="currentRegion">우리 동네</li>
          <li id="Nationwide">전국</li>
        </ul>
      </Modal>
```


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #91 

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
