### PR TITLE
fix: 마감 이미지 가운데 정렬 및 종료된 타이머 setInterval 제거

### DIFF
--- a/src/app/_component/common/Timer/Time.tsx
+++ b/src/app/_component/common/Timer/Time.tsx
@@ -4,19 +4,30 @@ import useTimer from "@/app/hooks/useTimer";
 
 interface TimeProps {
   deadline: Date;
+  hiddenTimer: boolean;
 }
 
-const Time = ({ deadline }: TimeProps) => {
+const Time = ({ deadline, hiddenTimer }: TimeProps) => {
   const timeRemaining = useTimer(deadline);
   const formatNumber = (num: number) => (num < 10 ? `0${num}` : `${num}`);
 
   const { days, hours, minutes, seconds } = timeRemaining;
 
   return (
-    <span aria-label="타이머">
-      {formatNumber(days)}:{formatNumber(hours)}:{formatNumber(minutes)}:
-      {formatNumber(seconds)}
-    </span>
+    <>
+      {days === 0 &&
+      hours === 0 &&
+      minutes === 0 &&
+      seconds === 0 &&
+      hiddenTimer ? (
+        <div className="h-[19px]"></div>
+      ) : (
+        <span aria-label="타이머">
+          {formatNumber(days)}:{formatNumber(hours)}:{formatNumber(minutes)}:
+          {formatNumber(seconds)}
+        </span>
+      )}
+    </>
   );
 };
 

--- a/src/app/_component/common/Timer/TimerContainer.tsx
+++ b/src/app/_component/common/Timer/TimerContainer.tsx
@@ -47,17 +47,19 @@ const TimerContainer = ({
           />
         )}
         <div className={cn("w-[90px] pt-[1px] pr-[2px] dark:border-white")}>
-          {children}
-          {isTimerFinished && (
-            <div className="absolute -bottom-2 left-8 w-[70px]">
-              <Image
-                src={deadlineImage}
-                alt="deadline"
-                className="w-full h-auto dark:saturate-200"
-                priority
-              />
-            </div>
-          )}
+          <div className="flex justify-center items-center ">
+            {children}
+            {isTimerFinished && (
+              <div className="absolute w-[70px]">
+                <Image
+                  src={deadlineImage}
+                  alt="deadline"
+                  className="w-full h-auto dark:saturate-200"
+                  priority
+                />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/_component/common/Timer/index.tsx
+++ b/src/app/_component/common/Timer/index.tsx
@@ -6,12 +6,14 @@ interface TimerProps {
   createdAt: Date | string;
   className?: string;
   isIcon?: boolean;
+  hiddenTimer?: boolean;
 }
 
 const Timer = ({
   createdAt,
   deadline,
   isIcon = true,
+  hiddenTimer = false,
   className
 }: TimerProps) => {
   if (deadline instanceof Date) {
@@ -28,7 +30,10 @@ const Timer = ({
       createdAt={processedCreatedAt}
       className={className}
       isIcon={isIcon}>
-      <Time deadline={processedDeadLine} />
+      <Time
+        deadline={processedDeadLine}
+        hiddenTimer={hiddenTimer}
+      />
     </TimerContainer>
   );
 };

--- a/src/app/hooks/useTimer.ts
+++ b/src/app/hooks/useTimer.ts
@@ -20,7 +20,17 @@ const useTimer = (deadline: Date): TimeRemaining => {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      setTimeRemaining(calculateTimeRemaining(deadline));
+      const newTimeRemaining = calculateTimeRemaining(deadline);
+      if (
+        newTimeRemaining.days === 0 &&
+        newTimeRemaining.hours === 0 &&
+        newTimeRemaining.minutes === 0 &&
+        newTimeRemaining.seconds === 0
+      ) {
+        clearInterval(intervalId);
+      } else {
+        setTimeRemaining(newTimeRemaining);
+      }
     }, 1000);
 
     return () => clearInterval(intervalId);


### PR DESCRIPTION
## 📑 구현 사항

- [x] 마감 이미지 가운데 정렬
- [x] 시간이 마감되면 타이머를 안보이게하는 hiddenTimer 추가
- [x] 종료된 타이머에 setInterval이 제거되지 않은 버그 해결



## 🚧 특이 사항

- 아래와 같이 사용함
```
import Timer from "./_component/common/Timer";

export default function Home() {
  const createdAt = new Date("2024-03-06T10:59:59");
  const deadline1 = new Date("2024-03-08T16:59:59");
  const deadline3 = new Date("2024-03-06T23:59:59");
  const deadline2 = new Date("2024-03-07T00:59:59");
  return (
    <main>
      <Timer
        createdAt={createdAt}
        deadline={deadline1}
      />
      <Timer
        createdAt={createdAt}
        deadline={deadline2}
      />
      <Timer
        createdAt={createdAt}
        deadline={deadline3}
      />
      <Timer
        createdAt={createdAt}
        deadline={deadline3}
        hiddenTimer={true} // 시간이 다 되면 타이머 숫자는 안보이게
        isIcon={false} // 아이콘 제거
      />
    </main>
  );
}

```
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/48e98c15-2728-4c83-aa61-52099aaee2b0)


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #119 

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
