### PR TITLE
feat: 입찰자 목록 페이지 구현

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,130 +2,130 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (2.2.3).
+ * Mock Service Worker (2.2.4).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = '223d191a56023cd36aa88c802961b911'
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
-const activeClientIds = new Set()
+const INTEGRITY_CHECKSUM = "223d191a56023cd36aa88c802961b911";
+const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
+const activeClientIds = new Set();
 
-self.addEventListener('install', function () {
-  self.skipWaiting()
-})
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
 
-self.addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim())
-})
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
 
-self.addEventListener('message', async function (event) {
-  const clientId = event.source.id
+self.addEventListener("message", async function (event) {
+  const clientId = event.source.id;
 
   if (!clientId || !self.clients) {
-    return
+    return;
   }
 
-  const client = await self.clients.get(clientId)
+  const client = await self.clients.get(clientId);
 
   if (!client) {
-    return
+    return;
   }
 
   const allClients = await self.clients.matchAll({
-    type: 'window',
-  })
+    type: "window"
+  });
 
   switch (event.data) {
-    case 'KEEPALIVE_REQUEST': {
+    case "KEEPALIVE_REQUEST": {
       sendToClient(client, {
-        type: 'KEEPALIVE_RESPONSE',
-      })
-      break
+        type: "KEEPALIVE_RESPONSE"
+      });
+      break;
     }
 
-    case 'INTEGRITY_CHECK_REQUEST': {
+    case "INTEGRITY_CHECK_REQUEST": {
       sendToClient(client, {
-        type: 'INTEGRITY_CHECK_RESPONSE',
-        payload: INTEGRITY_CHECKSUM,
-      })
-      break
+        type: "INTEGRITY_CHECK_RESPONSE",
+        payload: INTEGRITY_CHECKSUM
+      });
+      break;
     }
 
-    case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId)
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId);
 
       sendToClient(client, {
-        type: 'MOCKING_ENABLED',
-        payload: true,
-      })
-      break
+        type: "MOCKING_ENABLED",
+        payload: true
+      });
+      break;
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId);
+      break;
     }
 
-    case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId)
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId);
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId
-      })
+        return client.id !== clientId;
+      });
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister()
+        self.registration.unregister();
       }
 
-      break
+      break;
     }
   }
-})
+});
 
-self.addEventListener('fetch', function (event) {
-  const { request } = event
+self.addEventListener("fetch", function (event) {
+  const { request } = event;
 
   // Bypass navigation requests.
-  if (request.mode === 'navigate') {
-    return
+  if (request.mode === "navigate") {
+    return;
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return
+  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    return;
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return
+    return;
   }
 
   // Generate unique request ID.
-  const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
-})
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event)
-  const response = await getResponse(event, client, requestId)
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const responseClone = response.clone()
+    (async function () {
+      const responseClone = response.clone();
 
       sendToClient(
         client,
         {
-          type: 'RESPONSE',
+          type: "RESPONSE",
           payload: {
             requestId,
             isMockedResponse: IS_MOCKED_RESPONSE in response,
@@ -133,15 +133,15 @@ async function handleRequest(event, requestId) {
             status: responseClone.status,
             statusText: responseClone.statusText,
             body: responseClone.body,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-          },
+            headers: Object.fromEntries(responseClone.headers.entries())
+          }
         },
-        [responseClone.body],
-      )
-    })()
+        [responseClone.body]
+      );
+    })();
   }
 
-  return response
+  return response;
 }
 
 // Resolve the main client for the given event.
@@ -149,49 +149,49 @@ async function handleRequest(event, requestId) {
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId)
+  const client = await self.clients.get(event.clientId);
 
-  if (client?.frameType === 'top-level') {
-    return client
+  if (client?.frameType === "top-level") {
+    return client;
   }
 
   const allClients = await self.clients.matchAll({
-    type: 'window',
-  })
+    type: "window"
+  });
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible'
+      return client.visibilityState === "visible";
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id)
-    })
+      return activeClientIds.has(client.id);
+    });
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event
+  const { request } = event;
 
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone()
+  const requestClone = request.clone();
 
   function passthrough() {
-    const headers = Object.fromEntries(requestClone.headers.entries())
+    const headers = Object.fromEntries(requestClone.headers.entries());
 
     // Remove internal MSW request header so the passthrough request
     // complies with any potential CORS preflight checks on the server.
     // Some servers forbid unknown request headers.
-    delete headers['x-msw-intention']
+    delete headers["x-msw-intention"];
 
-    return fetch(requestClone, { headers })
+    return fetch(requestClone, { headers });
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough()
+    return passthrough();
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -199,22 +199,22 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough()
+    return passthrough();
   }
 
   // Bypass requests with the explicit bypass header.
   // Such requests can be issued by "ctx.fetch()".
-  const mswIntention = request.headers.get('x-msw-intention')
-  if (['bypass', 'passthrough'].includes(mswIntention)) {
-    return passthrough()
+  const mswIntention = request.headers.get("x-msw-intention");
+  if (["bypass", "passthrough"].includes(mswIntention)) {
+    return passthrough();
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer()
+  const requestBuffer = await request.arrayBuffer();
   const clientMessage = await sendToClient(
     client,
     {
-      type: 'REQUEST',
+      type: "REQUEST",
       payload: {
         id: requestId,
         url: request.url,
@@ -229,42 +229,42 @@ async function getResponse(event, client, requestId) {
         referrer: request.referrer,
         referrerPolicy: request.referrerPolicy,
         body: requestBuffer,
-        keepalive: request.keepalive,
-      },
+        keepalive: request.keepalive
+      }
     },
-    [requestBuffer],
-  )
+    [requestBuffer]
+  );
 
   switch (clientMessage.type) {
-    case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data)
+    case "MOCK_RESPONSE": {
+      return respondWithMock(clientMessage.data);
     }
 
-    case 'MOCK_NOT_FOUND': {
-      return passthrough()
+    case "MOCK_NOT_FOUND": {
+      return passthrough();
     }
   }
 
-  return passthrough()
+  return passthrough();
 }
 
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel()
+    const channel = new MessageChannel();
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error)
+        return reject(event.data.error);
       }
 
-      resolve(event.data)
-    }
+      resolve(event.data);
+    };
 
     client.postMessage(
       message,
-      [channel.port2].concat(transferrables.filter(Boolean)),
-    )
-  })
+      [channel.port2].concat(transferrables.filter(Boolean))
+    );
+  });
 }
 
 async function respondWithMock(response) {
@@ -273,15 +273,15 @@ async function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error()
+    return Response.error();
   }
 
-  const mockedResponse = new Response(response.body, response)
+  const mockedResponse = new Response(response.body, response);
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
-    enumerable: true,
-  })
+    enumerable: true
+  });
 
-  return mockedResponse
+  return mockedResponse;
 }

--- a/src/app/_component/common/AuctionDetailFooterBar/index.tsx
+++ b/src/app/_component/common/AuctionDetailFooterBar/index.tsx
@@ -1,21 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Link from "next/link";
 
-import { BidRequest } from "@/utils/types/bid/bids";
+import useVisibilityOnScroll from "@/app/_hooks/useVisibilityScroll";
+import { BidsResponse } from "@/utils/types/bid/bids";
 
 import Icon from "../Icon";
-import useVisibilityOnScroll from "@/app/_hooks/useVisibilityScroll";
 
 interface AuctionDetailDataProps {
+  auctionStatus: "입찰중" | "거래중" | "거래완료";
   bookmarkCount: number;
   auctionId: number;
-  bidsData: BidRequest;
+  bidsData: BidsResponse;
+  sellerId: number;
 }
 
 const AuctionDetailFooterBar = ({
+  auctionStatus,
   bidsData,
   auctionId,
+  sellerId,
   bookmarkCount
 }: AuctionDetailDataProps) => {
   const isVisible = useVisibilityOnScroll();
@@ -29,7 +33,6 @@ const AuctionDetailFooterBar = ({
       <div className="flex">
         <div className="flex">
           <Icon id="book-mark" />
-          {/*TODO: 좋아요 클릭 가능하게 구현 */}
           {bookmarkCount}
         </div>
         <div className="flex">
@@ -38,10 +41,13 @@ const AuctionDetailFooterBar = ({
         </div>
       </div>
       <div>
-        {/* TODO: 입찰자 목록 페이지 이동 Link 태그 추가 */}
-        <button className="bg-[#96E4FF] rounded-lg px-2 hover:bg-[#55d4ff]">
-          입찰자 목록으로 이동
-        </button>
+        {auctionStatus !== "입찰중" && (
+          <Link
+            href={`${auctionId}/bidderList?sellerId=${sellerId}`}
+            className="bg-[#96E4FF] rounded-lg px-2 hover:bg-[#55d4ff]">
+            입찰자 목록으로 이동
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/src/app/_component/common/BidderStatusItem/index.tsx
+++ b/src/app/_component/common/BidderStatusItem/index.tsx
@@ -1,0 +1,87 @@
+import Image from "next/image";
+import Avatar from "../Avatar";
+import Button from "../Button";
+
+export interface BidderStatusItemProps {
+  profileImage: string;
+  nickName: string;
+  biddingPrice: number;
+  status: "WAITING" | "PREPARING" | "PROGRESSING" | "CANCELED" | "COMPLETED";
+  isSeller: boolean;
+}
+
+const BidderStatusItem = ({
+  profileImage,
+  nickName,
+  biddingPrice,
+  status,
+  isSeller
+}: BidderStatusItemProps) => {
+  const renderStatus = () => {
+    const baseClass = "bg-[#96E4FF] p-2 rounded-lg transition-colors";
+    const hoverClass = "hover:opacity-60";
+
+    //TODO: 채팅방 생성하기 mutation 생성
+    //TODO: 채팅하기 Link 태그로 채팅방 이동
+    //TODO: 거래완료하기 mutation 생성
+    if (isSeller) {
+      switch (status) {
+        case "WAITING":
+          return <span className="text-slate-500 font-bold">대기중</span>;
+        case "PREPARING":
+          return (
+            <button className={`${baseClass} ${hoverClass}`}>
+              채팅방 생성하기
+            </button>
+          );
+        case "PROGRESSING":
+          return (
+            <div className="flex gap-2">
+              <button className={`${baseClass} ${hoverClass}`}>채팅하기</button>
+              <button className={`${baseClass} ${hoverClass} bg-blue-500`}>
+                완료 하기
+              </button>
+              <button className={`${baseClass} ${hoverClass} bg-red-500`}>
+                취소 하기
+              </button>
+            </div>
+          );
+        case "CANCELED":
+          return <span className="text-slate-500 font-bold">취소됨</span>;
+        case "COMPLETED":
+          return <span className={`${baseClass} font-bold`}>거래 완료</span>;
+        default:
+          return null;
+      }
+    } else {
+      switch (status) {
+        case "WAITING":
+          return <span className="text-slate-500 font-bold">대기중</span>;
+        case "PREPARING":
+          return <span className="text-slate-500 font-bold">거래 준비 중</span>;
+        case "PROGRESSING":
+          return <span className="text-slate-500 font-bold">얘기하는 중</span>;
+        case "CANCELED":
+          return <span className="text-slate-500 font-bold">취소됨</span>;
+        case "COMPLETED":
+          return <span className={`${baseClass} font-bold`}>거래 완료</span>;
+        default:
+          return null;
+      }
+    }
+  };
+  return (
+    <div className="flex justify-between items-center gap-4">
+      <div className="flex flex-col items-center">
+        <Avatar src={profileImage} />
+        <span className="text-xs">{nickName}</span>
+      </div>
+      <div>
+        <span>{biddingPrice}</span>
+      </div>
+      <div className="grow flex justify-center">{renderStatus()}</div>
+    </div>
+  );
+};
+
+export default BidderStatusItem;

--- a/src/app/_component/common/Comment/index.tsx
+++ b/src/app/_component/common/Comment/index.tsx
@@ -7,13 +7,13 @@ import {
 } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
-import { createComment } from "@/app/auctions/[auctionId]/_api/createComment";
 import useInfiniteScroll from "@/app/_hooks/useInfiniteScroll";
+import { createComment } from "@/app/auctions/[auctionId]/_api/createComment";
 import useGetCommentList from "@/app/auctions/[auctionId]/_hooks/queries/useGetCommentList";
+import { CommentListData } from "@/utils/types/comment/commentData";
 
 import ChatMessage from "../ChatMessage";
 import CommentInput, { FormDataType } from "./CommentInput";
-import { CommentListData } from "@/utils/types/comment/commentData";
 
 export interface CreateComment {
   comment: string;
@@ -68,7 +68,7 @@ const Comment = ({ auctionId = 12342 }: CommentProps) => {
   const onSubmit = (data: FormDataType) => {
     mutation.mutate({ comment: data.comment, auctionId });
     const exMessages = queryClient.getQueryData([
-      "product",
+      "auction",
       auctionId,
       "comments"
     ]) as InfiniteData<CommentListData>;

--- a/src/app/_component/common/LineChart/index.tsx
+++ b/src/app/_component/common/LineChart/index.tsx
@@ -45,9 +45,9 @@ interface LineChartProps {
 const LineChart = ({ bids }: LineChartProps) => {
   const { content } = bids;
 
-  const labels = content
-    .reverse()
-    .map((item) => new Date(item.createdAt).toLocaleDateString());
+  const labels = content.map((item) =>
+    new Date(item.createdAt).toLocaleDateString()
+  );
 
   const data = {
     labels,

--- a/src/app/_component/common/LineChart/index.tsx
+++ b/src/app/_component/common/LineChart/index.tsx
@@ -11,7 +11,7 @@ import {
 import React from "react";
 import { Line } from "react-chartjs-2";
 
-import { BidResponse } from "@/utils/types/bid/bids";
+import { BidsResponse } from "@/utils/types/bid/bids";
 
 ChartJS.register(
   CategoryScale,
@@ -39,15 +39,15 @@ export const options = {
 };
 
 interface LineChartProps {
-  bids: BidResponse;
+  bids: BidsResponse;
 }
 
 const LineChart = ({ bids }: LineChartProps) => {
   const { content } = bids;
 
-  const labels = content.map((item) =>
-    new Date(item.createdAt).toLocaleDateString()
-  );
+  const labels = content
+    .reverse()
+    .map((item) => new Date(item.createdAt).toLocaleDateString());
 
   const data = {
     labels,

--- a/src/app/_component/common/SlideCarousel/useDragScroll.ts
+++ b/src/app/_component/common/SlideCarousel/useDragScroll.ts
@@ -121,7 +121,6 @@ const useDragScroll = ({
   const buttonScrollRight = () => {
     if (!isButtonScroll) {
       setIsButtonScroll(true);
-      console.log(isButtonScroll);
       setTimeout(() => {
         if (containerRef.current) {
           containerRef.current.scrollBy({

--- a/src/app/_component/common/TopThreeRank/index.tsx
+++ b/src/app/_component/common/TopThreeRank/index.tsx
@@ -11,7 +11,7 @@ const TopThreeRank = ({ content }: { content: Top3BidData[] }) => {
 
   const maxYValue = maxBiddingPrice + maxBiddingPrice * 0.1;
 
-  const biddingPercentages = content.map((item, index) => ({
+  const biddingPercentages = content.reverse().map((item, index) => ({
     ...item,
     percentage: (item.biddingPrice / maxYValue) * 100,
     image:

--- a/src/app/auctions/[auctionId]/_api/getBids.ts
+++ b/src/app/auctions/[auctionId]/_api/getBids.ts
@@ -49,7 +49,7 @@ export async function getBidsReverse({
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/${auctionId}/bids`,
     {
       next: {
-        tags: ["bids"]
+        tags: ["bids", "reverse"]
       },
       cache: "no-store"
     }
@@ -70,7 +70,7 @@ export async function getTopThreeRankReverse({
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/${auctionId}/bids/top3`,
     {
       next: {
-        tags: ["top3"]
+        tags: ["top3", "reverse"]
       },
       cache: "no-store"
     }

--- a/src/app/auctions/[auctionId]/_api/getBids.ts
+++ b/src/app/auctions/[auctionId]/_api/getBids.ts
@@ -44,7 +44,7 @@ export async function getBidsReverse({
   auctionId
 }: {
   auctionId: number;
-}): Promise<BidResponse> {
+}): Promise<BidsResponse> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/${auctionId}/bids`,
     {

--- a/src/app/auctions/[auctionId]/_api/getBids.ts
+++ b/src/app/auctions/[auctionId]/_api/getBids.ts
@@ -1,4 +1,4 @@
-import { BidResponse } from "@/utils/types/bid/bids";
+import { BidsResponse } from "@/utils/types/bid/bids";
 import { Top3BidResponse } from "@/utils/types/bid/top3Bid";
 export async function getTopThreeRank({
   auctionId
@@ -24,7 +24,7 @@ export async function getBids({
   auctionId
 }: {
   auctionId: number;
-}): Promise<BidResponse> {
+}): Promise<BidsResponse> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/${auctionId}/bids`,
     {

--- a/src/app/auctions/[auctionId]/_component/DetailInfoSection.tsx
+++ b/src/app/auctions/[auctionId]/_component/DetailInfoSection.tsx
@@ -106,8 +106,10 @@ const DetailInfoSection = ({ auctionId }: DetailInfoSectionProps) => {
         <Comment auctionId={auctionId} />
         <AuctionDetailFooterBar
           bidsData={bids}
+          sellerId={auction.sellerInfo.userId}
           auctionId={auctionId}
           bookmarkCount={auction.bookmarkCount}
+          auctionStatus={auction.auctionStatus}
         />
       </div>
     </>

--- a/src/app/auctions/[auctionId]/_component/DetailInfoSection.tsx
+++ b/src/app/auctions/[auctionId]/_component/DetailInfoSection.tsx
@@ -102,7 +102,7 @@ const DetailInfoSection = ({ auctionId }: DetailInfoSectionProps) => {
         />
         <hr />
         <LineChart bids={bids} />
-        <TopThreeRank content={top3.content} />
+        <TopThreeRank content={top3.content.reverse()} />
         <Comment auctionId={auctionId} />
         <AuctionDetailFooterBar
           bidsData={bids}

--- a/src/app/auctions/[auctionId]/_hooks/queries/useGetAuctionDetail.ts
+++ b/src/app/auctions/[auctionId]/_hooks/queries/useGetAuctionDetail.ts
@@ -8,12 +8,12 @@ const useGetAuctionDetail = ({ auctionId }: { auctionId: number }) => {
     useSuspenseQueries({
       queries: [
         {
-          queryKey: ["auction", auctionId, "topThreeRank"],
+          queryKey: ["auction", auctionId, "topThreeRank", "reverse"],
           queryFn: () => getTopThreeRankReverse({ auctionId }),
           staleTime: 60 * 1000
         },
         {
-          queryKey: ["auction", auctionId, "bids"],
+          queryKey: ["auction", auctionId, "bids", "reverse"],
           queryFn: () => getBidsReverse({ auctionId }),
           staleTime: 60 * 1000
         },

--- a/src/app/auctions/[auctionId]/_hooks/queries/useGetCommentList.ts
+++ b/src/app/auctions/[auctionId]/_hooks/queries/useGetCommentList.ts
@@ -23,7 +23,7 @@ const useGetCommentList = ({ auctionId }: { auctionId: number }) => {
     [string, number, string],
     number
   >({
-    queryKey: ["product", auctionId, "comments"],
+    queryKey: ["auction", auctionId, "comments"],
     queryFn: ({ pageParam = 0 }) => getComments({ pageParam, auctionId }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {

--- a/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
@@ -1,3 +1,5 @@
+import { authCheck } from "@/utils/function/authCheck";
+
 export interface createChatRoomParams {
   auctionId: number;
   biddingId: number;
@@ -11,6 +13,12 @@ const createChatRoom = async ({
   auctionId,
   biddingId
 }: createChatRoomParams): Promise<createChatRoomResponse> => {
+  const isTokenValid = authCheck();
+
+  if (!isTokenValid) {
+    throw new Error("401");
+  }
+
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms?auctionId=${auctionId}&biddingId=${biddingId}`,
     {
@@ -19,8 +27,7 @@ const createChatRoom = async ({
         tags: ["chat", auctionId.toString(), biddingId.toString()]
       },
       headers: {
-        Authorization:
-          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+        Authorization: `Bearer ${isTokenValid}`
       },
       cache: "no-store"
     }

--- a/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
@@ -1,0 +1,29 @@
+export interface createChatRoomParams {
+  auctionId: number;
+  biddingId: number;
+}
+
+interface createChatRoomResponse {
+  chatRoomId: number;
+}
+
+const createChatRoom = async ({
+  auctionId,
+  biddingId
+}: createChatRoomParams): Promise<createChatRoomResponse> => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms&?auctionId=${auctionId}&biddingId=${biddingId}`,
+    {
+      next: {
+        tags: ["chat", auctionId.toString(), biddingId.toString()]
+      },
+      cache: "no-store"
+    }
+  );
+  if (!res.ok) throw new Error("Failed to fetch data [AuctionDetail] ");
+
+  const jsonData = await res.json();
+  return jsonData;
+};
+
+export default createChatRoom;

--- a/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/createChatRoom.ts
@@ -12,10 +12,15 @@ const createChatRoom = async ({
   biddingId
 }: createChatRoomParams): Promise<createChatRoomResponse> => {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms&?auctionId=${auctionId}&biddingId=${biddingId}`,
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms?auctionId=${auctionId}&biddingId=${biddingId}`,
     {
+      method: "POST",
       next: {
         tags: ["chat", auctionId.toString(), biddingId.toString()]
+      },
+      headers: {
+        Authorization:
+          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
       },
       cache: "no-store"
     }

--- a/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
@@ -1,18 +1,27 @@
+import { authCheck } from "@/utils/function/authCheck";
 import { CheckChatRoomInfoResponse } from "@/utils/types/chat/checkChatRoomInfrom";
 
 const getChatRoomInfo = async ({
   biddingId
 }: {
   biddingId: number | undefined;
-}): Promise<CheckChatRoomInfoResponse | null> => {
-  if (biddingId === undefined) return null;
+}): Promise<CheckChatRoomInfoResponse> => {
+  if (biddingId === undefined) {
+    throw new Error("400");
+  }
+
+  const isTokenValid = authCheck();
+
+  if (!isTokenValid) {
+    throw new Error("401");
+  }
+
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms/biddings/${biddingId}`,
     {
       cache: "no-store",
       headers: {
-        Authorization:
-          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+        Authorization: `Bearer ${isTokenValid}`
       }
     }
   );

--- a/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
@@ -1,0 +1,22 @@
+import { CheckChatRoomInfoResponse } from "@/utils/types/chat/checkChatRoomInfrom";
+
+const getChatRoomInfo = async ({
+  biddingId
+}: {
+  biddingId: number | undefined;
+}): Promise<CheckChatRoomInfoResponse | null> => {
+  if (biddingId === undefined) return null;
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms/biddings/${biddingId}`,
+    {
+      cache: "no-store",
+      headers: {
+        Authorization:
+          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+      }
+    }
+  );
+  return await res.json();
+};
+
+export default getChatRoomInfo;

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
@@ -1,9 +1,17 @@
+import { authCheck } from "@/utils/function/authCheck";
+
 const patchCancelBidder = async ({
   biddingId
 }: {
   biddingId: number | undefined;
 }) => {
-  if (biddingId === undefined) return;
+  if (biddingId === undefined) throw new Error("400");
+
+  const isTokenValid = authCheck();
+
+  if (!isTokenValid) {
+    throw new Error("401");
+  }
 
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bids/${biddingId}/cancel`,
@@ -11,8 +19,7 @@ const patchCancelBidder = async ({
       method: "PATCH",
       cache: "no-store",
       headers: {
-        Authorization:
-          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+        Authorization: `Bearer ${isTokenValid}`
       }
     }
   );

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
@@ -1,0 +1,12 @@
+const patchCancelBidder = async () => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/}`, {
+    method: "PATCH",
+    cache: "no-store"
+  });
+  if (!res.ok) throw new Error("Failed to fetch data [AuctionDetail] ");
+
+  const jsonData = await res.json();
+  return jsonData;
+};
+
+export default patchCancelBidder;

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCancelBidder.ts
@@ -1,8 +1,21 @@
-const patchCancelBidder = async () => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/}`, {
-    method: "PATCH",
-    cache: "no-store"
-  });
+const patchCancelBidder = async ({
+  biddingId
+}: {
+  biddingId: number | undefined;
+}) => {
+  if (biddingId === undefined) return;
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bids/${biddingId}/cancel`,
+    {
+      method: "PATCH",
+      cache: "no-store",
+      headers: {
+        Authorization:
+          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+      }
+    }
+  );
   if (!res.ok) throw new Error("Failed to fetch data [AuctionDetail] ");
 
   const jsonData = await res.json();

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
@@ -1,17 +1,25 @@
+import { authCheck } from "@/utils/function/authCheck";
+
 const patchCompleteTransaction = async ({
   biddingId
 }: {
   biddingId: number | undefined;
 }) => {
-  if (biddingId === undefined) return;
+  if (biddingId === undefined) throw new Error("400");
+
+  const isTokenValid = authCheck();
+
+  if (!isTokenValid) {
+    throw new Error("401");
+  }
+
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bids/${biddingId}/complete`,
     {
       method: "PATCH",
       cache: "no-store",
       headers: {
-        Authorization:
-          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+        Authorization: `Bearer ${isTokenValid}`
       }
     }
   );

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
@@ -1,8 +1,20 @@
-const patchCompleteTransaction = async () => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/}`, {
-    method: "PATCH",
-    cache: "no-store"
-  });
+const patchCompleteTransaction = async ({
+  biddingId
+}: {
+  biddingId: number | undefined;
+}) => {
+  if (biddingId === undefined) return;
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bids/${biddingId}/complete`,
+    {
+      method: "PATCH",
+      cache: "no-store",
+      headers: {
+        Authorization:
+          "Bearer eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjUsImlhdCI6MTcxMDMyNzk2MCwiZXhwIjoxNzExMTkxOTYwfQ.8IjNQwUpFplOcmUQO6LbtDk2Z8owwUiIGiO3f46rieM"
+      }
+    }
+  );
   if (!res.ok) throw new Error("Failed to fetch data [AuctionDetail] ");
 
   const jsonData = await res.json();

--- a/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/patchCompleteTransaction.ts
@@ -1,0 +1,12 @@
+const patchCompleteTransaction = async () => {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/}`, {
+    method: "PATCH",
+    cache: "no-store"
+  });
+  if (!res.ok) throw new Error("Failed to fetch data [AuctionDetail] ");
+
+  const jsonData = await res.json();
+  return jsonData;
+};
+
+export default patchCompleteTransaction;

--- a/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
@@ -1,69 +1,82 @@
-import Image from "next/image";
-import Avatar from "../Avatar";
-import Button from "../Button";
+import Link from "next/link";
+
+import Avatar from "@/app/_component/common/Avatar";
 
 export interface BidderStatusItemProps {
   profileImage: string;
   nickName: string;
   biddingPrice: number;
-  status: "WAITING" | "PREPARING" | "PROGRESSING" | "CANCELED" | "COMPLETED";
+  status: "대기중" | "준비중" | "진행중" | "취소됨" | "완료됨";
   isSeller: boolean;
+  chatRoomId: number | undefined;
+  biddingId: number;
+  createChatRoom: ({ biddingId }: { biddingId: number }) => void;
+  patchComplete: () => void;
+  patchCompleteIsLoading: boolean;
 }
 
 const BidderStatusItem = ({
   profileImage,
   nickName,
+  biddingId,
+  chatRoomId,
   biddingPrice,
   status,
-  isSeller
+  isSeller,
+  createChatRoom,
+  patchComplete,
+  patchCompleteIsLoading
 }: BidderStatusItemProps) => {
   const renderStatus = () => {
     const baseClass = "bg-[#96E4FF] p-2 rounded-lg transition-colors";
     const hoverClass = "hover:opacity-60";
 
-    //TODO: 채팅방 생성하기 mutation 생성
-    //TODO: 채팅하기 Link 태그로 채팅방 이동
-    //TODO: 거래완료하기 mutation 생성
     if (isSeller) {
       switch (status) {
-        case "WAITING":
+        case "대기중":
           return <span className="text-slate-500 font-bold">대기중</span>;
-        case "PREPARING":
+        case "준비중":
           return (
-            <button className={`${baseClass} ${hoverClass}`}>
+            <button
+              onClick={() => createChatRoom({ biddingId })}
+              className={`${baseClass} ${hoverClass}`}>
               채팅방 생성하기
             </button>
           );
-        case "PROGRESSING":
+        case "진행중":
           return (
             <div className="flex gap-2">
-              <button className={`${baseClass} ${hoverClass}`}>채팅하기</button>
-              <button className={`${baseClass} ${hoverClass} bg-blue-500`}>
+              <Link
+                href={`/auctions/chat-room/biddings/${chatRoomId}`}
+                className={`${baseClass} ${hoverClass}`}>
+                채팅하기
+              </Link>
+              <button
+                onClick={patchComplete}
+                disabled={patchCompleteIsLoading}
+                className={`${baseClass} ${hoverClass} bg-blue-500`}>
                 완료 하기
-              </button>
-              <button className={`${baseClass} ${hoverClass} bg-red-500`}>
-                취소 하기
               </button>
             </div>
           );
-        case "CANCELED":
+        case "취소됨":
           return <span className="text-slate-500 font-bold">취소됨</span>;
-        case "COMPLETED":
+        case "완료됨":
           return <span className={`${baseClass} font-bold`}>거래 완료</span>;
         default:
           return null;
       }
     } else {
       switch (status) {
-        case "WAITING":
+        case "대기중":
           return <span className="text-slate-500 font-bold">대기중</span>;
-        case "PREPARING":
+        case "준비중":
           return <span className="text-slate-500 font-bold">거래 준비 중</span>;
-        case "PROGRESSING":
+        case "진행중":
           return <span className="text-slate-500 font-bold">얘기하는 중</span>;
-        case "CANCELED":
+        case "취소됨":
           return <span className="text-slate-500 font-bold">취소됨</span>;
-        case "COMPLETED":
+        case "완료됨":
           return <span className={`${baseClass} font-bold`}>거래 완료</span>;
         default:
           return null;
@@ -77,7 +90,7 @@ const BidderStatusItem = ({
         <span className="text-xs">{nickName}</span>
       </div>
       <div>
-        <span>{biddingPrice}</span>
+        <span>{biddingPrice}원</span>
       </div>
       <div className="grow flex justify-center">{renderStatus()}</div>
     </div>

--- a/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
@@ -47,10 +47,15 @@ const BidderStatusItem = ({
           return (
             <div className="flex gap-2">
               <Link
-                href={`/auctions/chat-room/biddings/${chatRoomId}`}
+                href={`/chatrooms/${chatRoomId}`}
                 className={`${baseClass} ${hoverClass}`}>
                 채팅하기
               </Link>
+              <button
+                onClick={() => createChatRoom({ biddingId })}
+                className={`${baseClass} ${hoverClass}`}>
+                채팅방 생성하기
+              </button>
               <button
                 onClick={patchComplete}
                 disabled={patchCompleteIsLoading}

--- a/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
@@ -52,11 +52,6 @@ const BidderStatusItem = ({
                 채팅하기
               </Link>
               <button
-                onClick={() => createChatRoom({ biddingId })}
-                className={`${baseClass} ${hoverClass}`}>
-                채팅방 생성하기
-              </button>
-              <button
                 onClick={patchComplete}
                 disabled={patchCompleteIsLoading}
                 className={`${baseClass} ${hoverClass} bg-blue-500`}>

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
@@ -1,11 +1,21 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 
 import createChatRoom from "../_api/createChatRoom";
 
 const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
   const createChatRoomMutation = useMutation({
     mutationFn: ({ biddingId }: { biddingId: number }) =>
-      createChatRoom({ auctionId, biddingId })
+      createChatRoom({ auctionId, biddingId }),
+    onSuccess: (data) => {
+      router.push(`/chatrooms/${data.chatRoomId}`);
+      queryClient.invalidateQueries({
+        queryKey: ["auction", auctionId, "bids"]
+      });
+    }
   });
 
   return { mutation: createChatRoomMutation };

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+
+import createChatRoom from "../_api/createChatRoom";
+
+const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
+  const createChatRoomMutation = useMutation({
+    mutationFn: ({ biddingId }: { biddingId: number }) =>
+      createChatRoom({ auctionId, biddingId })
+  });
+
+  return { mutation: createChatRoomMutation };
+};
+export default useCreateChatRoom;

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
@@ -1,11 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
+import Toast from "@/app/_component/common/Toast";
+
 import createChatRoom from "../_api/createChatRoom";
 
 const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const toast = Toast();
 
   const createChatRoomMutation = useMutation({
     mutationFn: ({ biddingId }: { biddingId: number }) =>
@@ -15,6 +18,10 @@ const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]
       });
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.show("에러가 발생했습니다.", "warn-solid", 2000);
     }
   });
 

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useGetBids.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useGetBids.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getBids } from "../../_api/getBids";
+
+const useGetBids = ({ auctionId }: { auctionId: number }) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["auction", auctionId, "bids"],
+    queryFn: () => getBids({ auctionId }),
+    staleTime: 60 * 1000
+  });
+
+  return { data, isLoading, isError };
+};
+
+export default useGetBids;

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useGetChatRoomInfo.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useGetChatRoomInfo.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import getChatRoomInfo from "../_api/getChatRoomInfo";
+
+const useGetChatRoomInfo = ({
+  biddingId
+}: {
+  biddingId: number | undefined;
+}) => {
+  const { data, refetch } = useQuery({
+    queryKey: ["chat", "chat-room-info"],
+    queryFn: () => getChatRoomInfo({ biddingId }),
+    enabled: biddingId !== undefined
+  });
+
+  return { data, refetch };
+};
+
+export default useGetChatRoomInfo;

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import patchCompleteTransaction from "../_api/patchCompleteTransaction";
+
+const usePatchTransactionComplete = ({ auctionId }: { auctionId: number }) => {
+  const queryClient = useQueryClient();
+  const completeTransactionMutation = useMutation({
+    mutationFn: patchCompleteTransaction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["auction", auctionId, "bids"]
+      });
+    }
+  });
+
+  return { mutation: completeTransactionMutation };
+};
+export default usePatchTransactionComplete;

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
@@ -2,10 +2,16 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import patchCompleteTransaction from "../_api/patchCompleteTransaction";
 
-const usePatchTransactionComplete = ({ auctionId }: { auctionId: number }) => {
+const usePatchTransactionComplete = ({
+  auctionId,
+  biddingId
+}: {
+  auctionId: number;
+  biddingId: number | undefined;
+}) => {
   const queryClient = useQueryClient();
   const completeTransactionMutation = useMutation({
-    mutationFn: patchCompleteTransaction,
+    mutationFn: () => patchCompleteTransaction({ biddingId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTransactionComplete.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import Toast from "@/app/_component/common/Toast";
+
 import patchCompleteTransaction from "../_api/patchCompleteTransaction";
 
 const usePatchTransactionComplete = ({
@@ -10,12 +12,18 @@ const usePatchTransactionComplete = ({
   biddingId: number | undefined;
 }) => {
   const queryClient = useQueryClient();
+  const toast = Toast();
+
   const completeTransactionMutation = useMutation({
     mutationFn: () => patchCompleteTransaction({ biddingId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]
       });
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.show("에러가 발생했습니다.", "warn-solid", 2000);
     }
   });
 

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import patchCancelBidder from "../_api/patchCancelBidder";
+
+const usePatchTransactionCancel = ({ auctionId }: { auctionId: number }) => {
+  const queryClient = useQueryClient();
+  const completeTransactionMutation = useMutation({
+    mutationFn: patchCancelBidder,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["auction", auctionId, "bids"]
+      });
+    }
+  });
+
+  return { mutation: completeTransactionMutation };
+};
+export default usePatchTransactionCancel;

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
@@ -2,10 +2,16 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import patchCancelBidder from "../_api/patchCancelBidder";
 
-const usePatchTransactionCancel = ({ auctionId }: { auctionId: number }) => {
+const usePatchTransactionCancel = ({
+  auctionId,
+  biddingId
+}: {
+  auctionId: number;
+  biddingId: number | undefined;
+}) => {
   const queryClient = useQueryClient();
   const completeTransactionMutation = useMutation({
-    mutationFn: patchCancelBidder,
+    mutationFn: () => patchCancelBidder({ biddingId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/usePatchTranscationCancel.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import Toast from "@/app/_component/common/Toast";
+
 import patchCancelBidder from "../_api/patchCancelBidder";
 
 const usePatchTransactionCancel = ({
@@ -10,12 +12,18 @@ const usePatchTransactionCancel = ({
   biddingId: number | undefined;
 }) => {
   const queryClient = useQueryClient();
+  const toast = Toast();
+
   const completeTransactionMutation = useMutation({
     mutationFn: () => patchCancelBidder({ biddingId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]
       });
+    },
+    onError: (error) => {
+      console.log(error);
+      toast.show("에러가 발생했습니다.", "warn-solid", 2000);
     }
   });
 

--- a/src/app/auctions/[auctionId]/bidderList/layout.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/layout.tsx
@@ -1,0 +1,18 @@
+import ArrowBackButton from "@/app/_component/common/ArrowBackButton";
+import Header from "@/app/_component/common/Header";
+
+export default function BidderListLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main>
+      <Header
+        left={<ArrowBackButton />}
+        center={<h1 className="text-lg">입찰자 목록</h1>}
+      />
+      {children}
+    </main>
+  );
+}

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import BidderStatusItem from "./_component/BidderStatusItem";
 import useCreateChatRoom from "./_hooks/useCreateChatRoom";
 import useGetBids from "./_hooks/useGetBids";
+import useGetChatRoomInfo from "./_hooks/useGetChatRoomInfo";
 import usePatchTransactionComplete from "./_hooks/usePatchTransactionComplete";
 import usePatchTransactionCancel from "./_hooks/usePatchTranscationCancel";
 
@@ -15,33 +18,49 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   const { auctionId } = params;
   const numberOfAuctionId = Number(auctionId);
   const { sellerId } = searchParams;
+  const [progressingBiddingId, setProgressingBiddingId] = useState<
+    number | undefined
+  >();
 
-  const loginId = "10";
-  console.log(typeof auctionId);
+  const loginId = "5";
 
-  const { data, isLoading, isError } = useGetBids({
+  const {
+    data: bidsData,
+    isLoading: bidsDataLoading,
+    isError: bidsDataError
+  } = useGetBids({
     auctionId: numberOfAuctionId
   });
 
   const { mutation: completeMutation } = usePatchTransactionComplete({
-    auctionId: numberOfAuctionId
+    auctionId: numberOfAuctionId,
+    biddingId: progressingBiddingId
   });
   const { mutation: cancelMutation } = usePatchTransactionCancel({
-    auctionId: numberOfAuctionId
+    auctionId: numberOfAuctionId,
+    biddingId: progressingBiddingId
   });
   const { mutation: createChatRoomMutation } = useCreateChatRoom({
     auctionId: numberOfAuctionId
   });
 
-  //TODO: 현재 채팅방 생성하기 API로 받아오는 chatRoomId를 이용해서 채팅하기에도 활용가능한지 테스트해야함
-  //TODO : 왜냐하면 입찰아이디로 채팅방 상세조회를 get 해오려면 useQuery를 사용해야하는데 그럼 전체 입찰자 목록에서 현재 "진행중"인 입찰자를 찾고, 그 입찰자의 id를 넣어서 chatRoomId를 값으로 저장해야함
-  if (isLoading) return <div>Loading...</div>;
-  if (isError) return <div>에러 발생</div>;
-  if (!data) return <div>입찰자가 없음</div>;
+  const { data: chatRoomInfo } = useGetChatRoomInfo({
+    biddingId: progressingBiddingId
+  });
+  useEffect(() => {
+    setProgressingBiddingId(
+      bidsData?.content.find((x) => x.tradingStatus === "진행중")?.biddingId
+    );
+  }, [bidsData]);
+
+
+  if (bidsDataLoading) return <div>Loading...</div>;
+  if (bidsDataError) return <div>에러 발생</div>;
+  if (!bidsData) return <div>입찰자가 없음</div>;
 
   return (
     <main className="">
-      {data.content.map((data) => (
+      {bidsData.content.map((data) => (
         <BidderStatusItem
           key={data.biddingId}
           biddingId={data.biddingId}
@@ -50,15 +69,15 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
           nickName={data.bidderNickname}
           status={data.tradingStatus}
           isSeller={sellerId === loginId}
-          chatRoomId={createChatRoomMutation.data?.chatRoomId}
+          chatRoomId={chatRoomInfo?.chatRoomId}
           createChatRoom={createChatRoomMutation.mutate}
-          patchComplete={cancelMutation.mutate}
-          patchCompleteIsLoading={cancelMutation.isPending}
+          patchComplete={completeMutation.mutate}
+          patchCompleteIsLoading={completeMutation.isPending}
         />
       ))}
       <div className="flex justify-center items-center mt-12">
         <button
-          onClick={() => completeMutation.mutate}
+          onClick={() => cancelMutation.mutate()}
           className="bg-[#96E4FF] p-2 rounded-lg">
           다음 입찰자 선택하기
         </button>

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -1,88 +1,65 @@
-import ArrowBackButton from "@/app/_component/common/ArrowBackButton";
-import BidderStatusItem from "@/app/_component/common/BidderStatusItem";
-import Header from "@/app/_component/common/Header";
+"use client";
 
-export interface BidderContent {
-  biddingPrice: number;
-  auctionId: number;
-  bidderId: number;
-  bidderNickname: string;
-  imgUrl: string;
-  createdAt: string;
-  status: "WAITING" | "PREPARING" | "PROGRESSING" | "CANCELED" | "COMPLETED";
-}
-export interface dataType {
-  content: BidderContent[];
-  size: number;
-  hasNext: boolean;
-}
-
-const data: dataType = {
-  content: [
-    {
-      biddingPrice: 15000,
-      auctionId: 214,
-      bidderId: 1,
-      bidderNickname: "토낑",
-      imgUrl:
-        "https://img.freepik.com/premium-photo/adorable-rabbit-character_398492-14609.jpg",
-      createdAt: "2024-03-12",
-      status: "PROGRESSING"
-    },
-    {
-      biddingPrice: 14000,
-      auctionId: 214,
-      bidderId: 2,
-      bidderNickname: "도리",
-      imgUrl:
-        "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",
-      createdAt: "2024-03-12",
-      status: "WAITING"
-    },
-    {
-      biddingPrice: 13000,
-      auctionId: 214,
-      bidderId: 3,
-      bidderNickname: "하하",
-      imgUrl:
-        "https://www.urbanbrush.net/web/wp-content/uploads/edd/2022/11/urbanbrush-20221108214712319041.jpg",
-      createdAt: "2024-03-12",
-      status: "WAITING"
-    }
-  ],
-  size: 0,
-  hasNext: false
-};
+import BidderStatusItem from "./_component/BidderStatusItem";
+import useCreateChatRoom from "./_hooks/useCreateChatRoom";
+import useGetBids from "./_hooks/useGetBids";
+import usePatchTransactionComplete from "./_hooks/usePatchTransactionComplete";
+import usePatchTransactionCancel from "./_hooks/usePatchTranscationCancel";
 
 interface BidderListPageProps {
-  params: { auctionId: number };
+  params: { auctionId: string };
+  searchParams: { sellerId: string };
 }
 
-const BidderListPage = ({ params }: BidderListPageProps) => {
+const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   const { auctionId } = params;
-  const auctionSellerId = 24242;
-  const currentID = 24242;
+  const numberOfAuctionId = Number(auctionId);
+  const { sellerId } = searchParams;
 
-  //TODO: 다음입찰자 선택하기 mutation 생성
+  const loginId = "10";
+  console.log(typeof auctionId);
+
+  const { data, isLoading, isError } = useGetBids({
+    auctionId: numberOfAuctionId
+  });
+
+  const { mutation: completeMutation } = usePatchTransactionComplete({
+    auctionId: numberOfAuctionId
+  });
+  const { mutation: cancelMutation } = usePatchTransactionCancel({
+    auctionId: numberOfAuctionId
+  });
+  const { mutation: createChatRoomMutation } = useCreateChatRoom({
+    auctionId: numberOfAuctionId
+  });
+
+  //TODO: 현재 채팅방 생성하기 API로 받아오는 chatRoomId를 이용해서 채팅하기에도 활용가능한지 테스트해야함
+  //TODO : 왜냐하면 입찰아이디로 채팅방 상세조회를 get 해오려면 useQuery를 사용해야하는데 그럼 전체 입찰자 목록에서 현재 "진행중"인 입찰자를 찾고, 그 입찰자의 id를 넣어서 chatRoomId를 값으로 저장해야함
+  if (isLoading) return <div>Loading...</div>;
+  if (isError) return <div>에러 발생</div>;
+  if (!data) return <div>입찰자가 없음</div>;
 
   return (
     <main className="">
-      <Header
-        left={<ArrowBackButton />}
-        center={<h1 className="text-lg">입찰자 목록</h1>}
-      />
       {data.content.map((data) => (
         <BidderStatusItem
-          key={data.bidderId}
+          key={data.biddingId}
+          biddingId={data.biddingId}
           profileImage={data.imgUrl}
           biddingPrice={data.biddingPrice}
           nickName={data.bidderNickname}
-          status={data.status}
-          isSeller={auctionSellerId === currentID}
+          status={data.tradingStatus}
+          isSeller={sellerId === loginId}
+          chatRoomId={createChatRoomMutation.data?.chatRoomId}
+          createChatRoom={createChatRoomMutation.mutate}
+          patchComplete={cancelMutation.mutate}
+          patchCompleteIsLoading={cancelMutation.isPending}
         />
       ))}
       <div className="flex justify-center items-center mt-12">
-        <button className="bg-[#96E4FF] p-2 rounded-lg">
+        <button
+          onClick={() => completeMutation.mutate}
+          className="bg-[#96E4FF] p-2 rounded-lg">
           다음 입찰자 선택하기
         </button>
       </div>

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -1,0 +1,93 @@
+import ArrowBackButton from "@/app/_component/common/ArrowBackButton";
+import BidderStatusItem from "@/app/_component/common/BidderStatusItem";
+import Header from "@/app/_component/common/Header";
+
+export interface BidderContent {
+  biddingPrice: number;
+  auctionId: number;
+  bidderId: number;
+  bidderNickname: string;
+  imgUrl: string;
+  createdAt: string;
+  status: "WAITING" | "PREPARING" | "PROGRESSING" | "CANCELED" | "COMPLETED";
+}
+export interface dataType {
+  content: BidderContent[];
+  size: number;
+  hasNext: boolean;
+}
+
+const data: dataType = {
+  content: [
+    {
+      biddingPrice: 15000,
+      auctionId: 214,
+      bidderId: 1,
+      bidderNickname: "토낑",
+      imgUrl:
+        "https://img.freepik.com/premium-photo/adorable-rabbit-character_398492-14609.jpg",
+      createdAt: "2024-03-12",
+      status: "PROGRESSING"
+    },
+    {
+      biddingPrice: 14000,
+      auctionId: 214,
+      bidderId: 2,
+      bidderNickname: "도리",
+      imgUrl:
+        "https://png.pngtree.com/thumb_back/fh260/background/20230609/pngtree-three-puppies-with-their-mouths-open-are-posing-for-a-photo-image_2902292.jpg",
+      createdAt: "2024-03-12",
+      status: "WAITING"
+    },
+    {
+      biddingPrice: 13000,
+      auctionId: 214,
+      bidderId: 3,
+      bidderNickname: "하하",
+      imgUrl:
+        "https://www.urbanbrush.net/web/wp-content/uploads/edd/2022/11/urbanbrush-20221108214712319041.jpg",
+      createdAt: "2024-03-12",
+      status: "WAITING"
+    }
+  ],
+  size: 0,
+  hasNext: false
+};
+
+interface BidderListPageProps {
+  params: { auctionId: number };
+}
+
+const BidderListPage = ({ params }: BidderListPageProps) => {
+  const { auctionId } = params;
+  const auctionSellerId = 24242;
+  const currentID = 24242;
+
+  //TODO: 다음입찰자 선택하기 mutation 생성
+
+  return (
+    <main className="">
+      <Header
+        left={<ArrowBackButton />}
+        center={<h1 className="text-lg">입찰자 목록</h1>}
+      />
+      {data.content.map((data) => (
+        <BidderStatusItem
+          key={data.bidderId}
+          profileImage={data.imgUrl}
+          biddingPrice={data.biddingPrice}
+          nickName={data.bidderNickname}
+          status={data.status}
+          isSeller={auctionSellerId === currentID}
+        />
+      ))}
+      <div className="flex justify-center items-center mt-12">
+        <button className="bg-[#96E4FF] p-2 rounded-lg">
+          다음 입찰자 선택하기
+        </button>
+      </div>
+    </main>
+  );
+};
+
+export default BidderListPage;

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -22,7 +22,7 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
     number | undefined
   >();
 
-  const loginId = "5";
+  const loginId = "10";
 
   const {
     data: bidsData,
@@ -47,12 +47,12 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   const { data: chatRoomInfo } = useGetChatRoomInfo({
     biddingId: progressingBiddingId
   });
+
   useEffect(() => {
     setProgressingBiddingId(
       bidsData?.content.find((x) => x.tradingStatus === "진행중")?.biddingId
     );
   }, [bidsData]);
-
 
   if (bidsDataLoading) return <div>Loading...</div>;
   if (bidsDataError) return <div>에러 발생</div>;

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -19,19 +19,20 @@ interface AuctionProps {
 
 const Auction = async ({ params }: AuctionProps) => {
   const { auctionId } = params;
-
+  const numberOfAuctionId = Number(auctionId);
   const queryClient = new QueryClient();
+
   await queryClient.prefetchQuery({
     queryKey: ["auction", auctionId],
-    queryFn: () => getAuctionDetail({ auctionId: Number(auctionId) })
+    queryFn: () => getAuctionDetail({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchQuery({
     queryKey: ["auction", auctionId, "topThreeRank"],
-    queryFn: () => getTopThreeRankReverse({ auctionId: Number(auctionId) })
+    queryFn: () => getTopThreeRankReverse({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchQuery({
     queryKey: ["auction", auctionId, "bids"],
-    queryFn: () => getBidsReverse({ auctionId: Number(auctionId) })
+    queryFn: () => getBidsReverse({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchInfiniteQuery<
     CommentListData,
@@ -40,9 +41,9 @@ const Auction = async ({ params }: AuctionProps) => {
     [string, number, string],
     number
   >({
-    queryKey: ["auction", Number(auctionId), "comments"],
+    queryKey: ["auction", numberOfAuctionId, "comments"],
     queryFn: ({ pageParam = 0 }) =>
-      getComments({ pageParam, auctionId: Number(auctionId) }),
+      getComments({ pageParam, auctionId: numberOfAuctionId }),
     initialPageParam: 0
   });
   const dehydratedState = dehydrate(queryClient);
@@ -50,10 +51,12 @@ const Auction = async ({ params }: AuctionProps) => {
   return (
     <section>
       <HydrationBoundary state={dehydratedState}>
-        <DetailInfoSection auctionId={Number(auctionId)} />
+        <DetailInfoSection auctionId={numberOfAuctionId} />
       </HydrationBoundary>
     </section>
   );
 };
 
 export default Auction;
+
+//eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjExLCJpYXQiOjE3MTA1OTA1NjUsImV4cCI6MTcxMTQ1NDU2NX0.bmIP_BoJNZTX2OeKlMzNA52x6fT8jeVc9fg9UlTWjrI

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -27,11 +27,11 @@ const Auction = async ({ params }: AuctionProps) => {
     queryFn: () => getAuctionDetail({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchQuery({
-    queryKey: ["auction", auctionId, "topThreeRank"],
+    queryKey: ["auction", auctionId, "topThreeRank", "reverse"],
     queryFn: () => getTopThreeRankReverse({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchQuery({
-    queryKey: ["auction", auctionId, "bids"],
+    queryKey: ["auction", auctionId, "bids", "reverse"],
     queryFn: () => getBidsReverse({ auctionId: numberOfAuctionId })
   });
   await queryClient.prefetchInfiniteQuery<

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -58,5 +58,3 @@ const Auction = async ({ params }: AuctionProps) => {
 };
 
 export default Auction;
-
-//eyJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOjExLCJpYXQiOjE3MTA1OTA1NjUsImV4cCI6MTcxMTQ1NDU2NX0.bmIP_BoJNZTX2OeKlMzNA52x6fT8jeVc9fg9UlTWjrI

--- a/src/utils/function/cookie.ts
+++ b/src/utils/function/cookie.ts
@@ -21,11 +21,12 @@ export const getCookie = ({ name }: getCookieParams) => {
     return trimmedCookie.startsWith(name + "=");
   });
 
-  const cookieValues = filteredCookies.map((cookie) =>
-    cookie.substring(name.length + 2).trim()
-  );
+  const cookieValues = filteredCookies
+    .join("")
+    .trim()
+    .substring(name.length + 1);
 
-  return cookieValues.join(", ").length <= 0 ? null : cookieValues.join(", ");
+  return cookieValues.length <= 0 ? null : cookieValues;
 };
 
 export const setCookie = ({ name, value, options = {} }: setCookieParams) => {

--- a/src/utils/mocks/api/searchApis.ts
+++ b/src/utils/mocks/api/searchApis.ts
@@ -1,7 +1,7 @@
-import { HttpResponse, http } from "msw";
+import { http, HttpResponse } from "msw";
 
-import { postListData } from "./data/postListData";
 import { popularSearchData } from "./data/popularSearchData";
+import { postListData } from "./data/postListData";
 
 const handler = [
   http.get("/api/search/popularkeyword", async () => {

--- a/src/utils/types/bid/bids.ts
+++ b/src/utils/types/bid/bids.ts
@@ -1,4 +1,4 @@
-export interface BidResponse {
+export interface BidsResponse {
   content: BidsData[];
   size: number;
   hasNext: boolean;
@@ -10,6 +10,7 @@ export interface BidsData {
   auctionId: number;
   bidderId: number;
   bidderNickname: string;
+  tradingStatus: "대기중" | "준비중" | "진행중" | "취소됨" | "완료됨";
   imgUrl: string;
   createdAt: string | Date;
 }

--- a/src/utils/types/chat/checkChatRoomInfrom.ts
+++ b/src/utils/types/chat/checkChatRoomInfrom.ts
@@ -1,4 +1,4 @@
-export interface CheckChatRoomInformRequest {
+export interface CheckChatRoomInfoResponse {
   chatRoomId: number;
   auctionId: number;
   auctionTitle: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,16 +1509,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/app-compat@npm:0.2.28":
-  version: 0.2.28
-  resolution: "@firebase/app-compat@npm:0.2.28"
+"@firebase/app-compat@npm:0.2.29":
+  version: 0.2.29
+  resolution: "@firebase/app-compat@npm:0.2.29"
   dependencies:
-    "@firebase/app": "npm:0.9.28"
+    "@firebase/app": "npm:0.9.29"
     "@firebase/component": "npm:0.6.5"
     "@firebase/logger": "npm:0.4.0"
     "@firebase/util": "npm:1.9.4"
     tslib: "npm:^2.1.0"
-  checksum: 10c0/9eedf134d1446516fa91eea6e933ddc093eeaa77c09633e9de646a470b9b5441af220f2d296100592d98cf6f3655d8e3834e4a8f2323bf5a3390d5e1a6ff889f
+  checksum: 10c0/21b9f56dee46dff67b976705139df0fb543553ced3f3858bc1ea4419be235dfde94ea5e6104db422c4a225bf02554adf9d476862243bd5c1759086f157bf9108
   languageName: node
   linkType: hard
 
@@ -1529,24 +1529,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/app@npm:0.9.28":
-  version: 0.9.28
-  resolution: "@firebase/app@npm:0.9.28"
+"@firebase/app@npm:0.9.29":
+  version: 0.9.29
+  resolution: "@firebase/app@npm:0.9.29"
   dependencies:
     "@firebase/component": "npm:0.6.5"
     "@firebase/logger": "npm:0.4.0"
     "@firebase/util": "npm:1.9.4"
     idb: "npm:7.1.1"
     tslib: "npm:^2.1.0"
-  checksum: 10c0/d684a6e071ade5685db94f7849fb9f9550134e7199dcfccfe3bd1418d7251ef58f7777ed0250814f15f6d4126e4d58d21efef2be579f0649748165516868cf04
+  checksum: 10c0/6c151c60fa57c1bdceccc53282f27625be8040c63f7a9d3d6419bc2d4c7e48cd82eebf1fcfb1656032a9805d647f86099311596780b7b900eb78d1f53e7b07ab
   languageName: node
   linkType: hard
 
-"@firebase/auth-compat@npm:0.5.3":
-  version: 0.5.3
-  resolution: "@firebase/auth-compat@npm:0.5.3"
+"@firebase/auth-compat@npm:0.5.4":
+  version: 0.5.4
+  resolution: "@firebase/auth-compat@npm:0.5.4"
   dependencies:
-    "@firebase/auth": "npm:1.6.1"
+    "@firebase/auth": "npm:1.6.2"
     "@firebase/auth-types": "npm:0.12.0"
     "@firebase/component": "npm:0.6.5"
     "@firebase/util": "npm:1.9.4"
@@ -1554,7 +1554,7 @@ __metadata:
     undici: "npm:5.28.3"
   peerDependencies:
     "@firebase/app-compat": 0.x
-  checksum: 10c0/ad8b6cb7cd3e666fed3044a1e9200dd5f54310ea10de1dc4893be5570e7d0c68d233491cb467fa153eec9a57de05c48081b0257c77e0cc3edaade00ba1f04c10
+  checksum: 10c0/e25500afe2fbe8f2536f062a103ed80425638bef5a026ce665b7abc970b087f77fef5bff831e5c688915c4ca0356fc1480ef3acf7afe51fc4e60acaf598a8796
   languageName: node
   linkType: hard
 
@@ -1575,9 +1575,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/auth@npm:1.6.1":
-  version: 1.6.1
-  resolution: "@firebase/auth@npm:1.6.1"
+"@firebase/auth@npm:1.6.2":
+  version: 1.6.2
+  resolution: "@firebase/auth@npm:1.6.2"
   dependencies:
     "@firebase/component": "npm:0.6.5"
     "@firebase/logger": "npm:0.4.0"
@@ -1590,7 +1590,7 @@ __metadata:
   peerDependenciesMeta:
     "@react-native-async-storage/async-storage":
       optional: true
-  checksum: 10c0/cf8bfe821c90358a2f74a8a95338e60108b5cbae07b233ecdcc77bb1fa40ff9a940cd9e81b37d6868a3e3938e18bbe14787bb159b5483d89bcdeb06de028d161
+  checksum: 10c0/ef73b0039a76e0120222314fe60b2101acb1c90cae31490fbec3f89d0cb7ccca80be35ecf261b84d7ff3682ada0638f30bf4d3a3670e848f1e7f96e3908dd7e5
   languageName: node
   linkType: hard
 
@@ -1643,18 +1643,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/firestore-compat@npm:0.3.26":
-  version: 0.3.26
-  resolution: "@firebase/firestore-compat@npm:0.3.26"
+"@firebase/firestore-compat@npm:0.3.27":
+  version: 0.3.27
+  resolution: "@firebase/firestore-compat@npm:0.3.27"
   dependencies:
     "@firebase/component": "npm:0.6.5"
-    "@firebase/firestore": "npm:4.4.3"
+    "@firebase/firestore": "npm:4.5.0"
     "@firebase/firestore-types": "npm:3.0.0"
     "@firebase/util": "npm:1.9.4"
     tslib: "npm:^2.1.0"
   peerDependencies:
     "@firebase/app-compat": 0.x
-  checksum: 10c0/3b20855406020f19cf06b036efa50bab32fb7766049ed41a21d657fe474edaabcc4e6b31a3bdea3a01f833c9a0269c11055cbe3e5e2cd83068181b211ef044a0
+  checksum: 10c0/e24f09652428902b3c8845fe8699beeaf1e500a3fb13406bcfaf423e4a5b0875775ae05421a699af73f2be3a324ecbeffeecc55be80d674769c7e020cc6b1a6b
   languageName: node
   linkType: hard
 
@@ -1668,9 +1668,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/firestore@npm:4.4.3":
-  version: 4.4.3
-  resolution: "@firebase/firestore@npm:4.4.3"
+"@firebase/firestore@npm:4.5.0":
+  version: 4.5.0
+  resolution: "@firebase/firestore@npm:4.5.0"
   dependencies:
     "@firebase/component": "npm:0.6.5"
     "@firebase/logger": "npm:0.4.0"
@@ -1682,7 +1682,7 @@ __metadata:
     undici: "npm:5.28.3"
   peerDependencies:
     "@firebase/app": 0.x
-  checksum: 10c0/9ad7d1db158675ba2483bbfdaa5d012f39593186cfbef2bb02c2ea5e490e4637c68545e0fa0fa69290e70a2fb8ba8a0062cee078f48855434b9163ea3b22c69d
+  checksum: 10c0/925a899e1160e8c958680f4baf13ba8ae99c6b3f255fb9345bc4b0d875e0bb31fb99b9e228afb590b0d1952bb9e53e952dad8c16f95a70bbf15960978ea3c022
   languageName: node
   linkType: hard
 
@@ -2601,51 +2601,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:5.27.5":
-  version: 5.27.5
-  resolution: "@tanstack/query-core@npm:5.27.5"
-  checksum: 10c0/e0a06216de04c2b62d278a666c16ac9dc3cad82d97202ca87ecfb09272912e508a4d365947f98ef4f2d53d46d7a1c1d1011e05d3a9da1e50ba70419e7a385bd7
+"@tanstack/query-core@npm:5.28.4":
+  version: 5.28.4
+  resolution: "@tanstack/query-core@npm:5.28.4"
+  checksum: 10c0/0aca64c0e20c56fb4b6c0497f29613b0eb5c02eb2e2f99f2ed5616d7c119c18259c7171d25f593d00cd50e9ee1d2e629388968fcd53d0aa7fa95d820fc58cf9c
   languageName: node
   linkType: hard
 
-"@tanstack/query-devtools@npm:5.27.8":
-  version: 5.27.8
-  resolution: "@tanstack/query-devtools@npm:5.27.8"
-  checksum: 10c0/6be9cb45f114b04a567aee142e30db366ea75a14746ee1005d06014c55f65c780a8ebeeb9a7622763374a9038ec2765b930b8f930c6e7da4613273302e70cf5d
+"@tanstack/query-devtools@npm:5.28.3":
+  version: 5.28.3
+  resolution: "@tanstack/query-devtools@npm:5.28.3"
+  checksum: 10c0/5a7db6e96ce0a4ca28eb121cb6d49d4e1de605b814cc5cd213a9300136d50187cc6ca07642ffa02a5ecb4085b66eb55a9a584e21a88ddb981c7aecab5ef79386
   languageName: node
   linkType: hard
 
 "@tanstack/react-query-devtools@npm:^5.18.1":
-  version: 5.27.8
-  resolution: "@tanstack/react-query-devtools@npm:5.27.8"
+  version: 5.28.4
+  resolution: "@tanstack/react-query-devtools@npm:5.28.4"
   dependencies:
-    "@tanstack/query-devtools": "npm:5.27.8"
+    "@tanstack/query-devtools": "npm:5.28.3"
   peerDependencies:
-    "@tanstack/react-query": ^5.27.5
+    "@tanstack/react-query": ^5.28.4
     react: ^18.0.0
-  checksum: 10c0/e04287fe9ab6715cc38cd8c41fb44eb93ec01daaa1497a7bb93fa65e6b47f8478fde8cac0537d8de75853f5692f6252b91d521b5c1607fdbefe4b7b786aca23f
+  checksum: 10c0/f790247887cc1991e986351cd071092215222b1e7c8349b4183b53dfa1f40e1f7ea410b79011b3dcb591089ffa3d9fe47359bfea77c48f36904255776cbe6324
   languageName: node
   linkType: hard
 
 "@tanstack/react-query-next-experimental@npm:^5.18.1":
-  version: 5.27.5
-  resolution: "@tanstack/react-query-next-experimental@npm:5.27.5"
+  version: 5.28.4
+  resolution: "@tanstack/react-query-next-experimental@npm:5.28.4"
   peerDependencies:
-    "@tanstack/react-query": ^5.27.5
+    "@tanstack/react-query": ^5.28.4
     next: ^13 || ^14
     react: ^18.0.0
-  checksum: 10c0/dd5a6b49950d9c043e9c5b75e9224faba173eaaa31a02e9669a8ee686db95e16b1adea613c8c4d1b30a90a85dc9d1a6796a3782115c5a97427aaf1cd3e76a03f
+  checksum: 10c0/00d4fafa95f9e89c51c482c9ea51d1d92e0fe1abb6862bc596a43b497ed8f34eb679b0b79570e49aa81f87d7c473f96a7dfdfa11fccf2ccacaf4a95ba4f69ef8
   languageName: node
   linkType: hard
 
 "@tanstack/react-query@npm:^5.18.1":
-  version: 5.27.5
-  resolution: "@tanstack/react-query@npm:5.27.5"
+  version: 5.28.4
+  resolution: "@tanstack/react-query@npm:5.28.4"
   dependencies:
-    "@tanstack/query-core": "npm:5.27.5"
+    "@tanstack/query-core": "npm:5.28.4"
   peerDependencies:
     react: ^18.0.0
-  checksum: 10c0/2ca456e763d94b454ab6d6506b8b033863bcf1095fd2925edd29ef88bca4de23acec0d24507f9aa7ef737d0cb1298ee97f011470e19131312a32f832b4c10ff0
+  checksum: 10c0/5ffc31cedea548b697770c018fab7fcd35724caf6cf7d40a7370ef6ffeb2427f510ea9745a92ebd6e74f2c4c39a255eabcd2a181c97b54991563ad842945866e
   languageName: node
   linkType: hard
 
@@ -2797,11 +2797,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^20, @types/node@npm:^20.11.26":
-  version: 20.11.26
-  resolution: "@types/node@npm:20.11.26"
+  version: 20.11.28
+  resolution: "@types/node@npm:20.11.28"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 10c0/2df81e4f109588c4c490f2c7d616a06d2b3b9298f217468134b80711af810c9a6017a59beb3e6b1c596eb9b6c5a39d33403b99179acb89006badfbc55f2468bb
+  checksum: 10c0/c599745243ed9ae4ca87460f18f88d02ab7424b545136aa504ed7a1d898e3a9bb133c927bcc7e861f79d7f6043ef917a173e780c8a001e129221e92f6d97b0ee
   languageName: node
   linkType: hard
 
@@ -2838,22 +2838,22 @@ __metadata:
   linkType: hard
 
 "@types/react-dom@npm:*, @types/react-dom@npm:^18":
-  version: 18.2.21
-  resolution: "@types/react-dom@npm:18.2.21"
+  version: 18.2.22
+  resolution: "@types/react-dom@npm:18.2.22"
   dependencies:
     "@types/react": "npm:*"
-  checksum: 10c0/a887b4b647071df48173f054854713b68fdacfceeba7fa14f64ba26688d7d43574d7dc88a2a346e28f2e667eeab1b9bdbcad8a54353869835e52638607f61ff5
+  checksum: 10c0/cd85b5f402126e44b8c7b573e74737389816abcc931b2b14d8f946ba81cce8637ea490419488fcae842efb1e2f69853bc30522e43fd8359e1007d4d14b8d8146
   languageName: node
   linkType: hard
 
 "@types/react@npm:*, @types/react@npm:^18":
-  version: 18.2.65
-  resolution: "@types/react@npm:18.2.65"
+  version: 18.2.66
+  resolution: "@types/react@npm:18.2.66"
   dependencies:
     "@types/prop-types": "npm:*"
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10c0/91158b5a9e90489a5984bb610c3692001ecdf1d286c78384252698bcb306ef88e9434e75f01bf7739017e949e7690b7d6f1b7ef9d7097f86f3f649482a33604b
+  checksum: 10c0/56e4b841f2daf03a0b3268d4f2bcf5841167fe56742b9f1c076fad66587fb59191bdaba4d5727dbfbcff750d5e8797fdd4e57d8d9704b0bfc6ad31ee1e268a70
   languageName: node
   linkType: hard
 
@@ -3469,15 +3469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asynciterator.prototype@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "asynciterator.prototype@npm:1.0.0"
-  dependencies:
-    has-symbols: "npm:^1.0.3"
-  checksum: 10c0/fb76850e57d931ff59fd16b6cddb79b0d34fe45f400b2c3480d38892e72cd089787401687dbdb7cdb14ece402c275d3e02a648760d1489cd493527129c4c6204
-  languageName: node
-  linkType: hard
-
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -3527,13 +3518,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.6.7":
-  version: 1.6.7
-  resolution: "axios@npm:1.6.7"
+  version: 1.6.8
+  resolution: "axios@npm:1.6.8"
   dependencies:
-    follow-redirects: "npm:^1.15.4"
+    follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/131bf8e62eee48ca4bd84e6101f211961bf6a21a33b95e5dfb3983d5a2fe50d9fffde0b57668d7ce6f65063d3dc10f2212cbcb554f75cfca99da1c73b210358d
+  checksum: 10c0/0f22da6f490335479a89878bc7d5a1419484fbb437b564a80c34888fc36759ae4f56ea28d55a191695e5ed327f0bad56e7ff60fb6770c14d1be6501505d47ab9
   languageName: node
   linkType: hard
 
@@ -3619,9 +3610,9 @@ __metadata:
   linkType: hard
 
 "binary-extensions@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "binary-extensions@npm:2.2.0"
-  checksum: 10c0/d73d8b897238a2d3ffa5f59c0241870043aa7471335e89ea5e1ff48edb7c2d0bb471517a3e4c5c3f4c043615caa2717b5f80a5e61e07503d51dc85cb848e665d
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
   languageName: node
   linkType: hard
 
@@ -4116,9 +4107,9 @@ __metadata:
   linkType: hard
 
 "date-fns@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "date-fns@npm:3.4.0"
-  checksum: 10c0/e4395adcdf10b1784c6479b9d715ed9a1cb06c9d99b95607ad6db43b18371e22314d3e9e5509a378da1c5a6b34b313049bf82897b7f263f413e051f59e0ea5c2
+  version: 3.5.0
+  resolution: "date-fns@npm:3.5.0"
+  checksum: 10c0/588866a963af617c46f71d7ae4971d2e88bce67bda39916f03ec6c2807c0344da27c4793d718a9082e7651d37a4c9ffaecc1cc1dee057d6eafcd85535a795a9f
   languageName: node
   linkType: hard
 
@@ -4305,9 +4296,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.668":
-  version: 1.4.702
-  resolution: "electron-to-chromium@npm:1.4.702"
-  checksum: 10c0/64548890f8eb612d3a9fbe6cf4f1948d82ca0ac34214f17b82494fe896afa97cc014a5edf17c3507f8e2edc50a469a387c619c0e0dc53871add7b28558fbd0dc
+  version: 1.4.708
+  resolution: "electron-to-chromium@npm:1.4.708"
+  checksum: 10c0/0232dd6f96bfeb8c2ffe69ab7698e8566be731b467eb4778a74da3070274f4521590d7638248177b2f70e1e8c629b255df80991594127d56069c355850d821dd
   languageName: node
   linkType: hard
 
@@ -4372,7 +4363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.22.4":
+"es-abstract@npm:^1.22.1, es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0":
   version: 1.23.0
   resolution: "es-abstract@npm:1.23.0"
   dependencies:
@@ -4449,29 +4440,28 @@ __metadata:
   linkType: hard
 
 "es-iterator-helpers@npm:^1.0.15, es-iterator-helpers@npm:^1.0.17":
-  version: 1.0.17
-  resolution: "es-iterator-helpers@npm:1.0.17"
+  version: 1.0.18
+  resolution: "es-iterator-helpers@npm:1.0.18"
   dependencies:
-    asynciterator.prototype: "npm:^1.0.0"
     call-bind: "npm:^1.0.7"
     define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.22.4"
+    es-abstract: "npm:^1.23.0"
     es-errors: "npm:^1.3.0"
-    es-set-tostringtag: "npm:^2.0.2"
+    es-set-tostringtag: "npm:^2.0.3"
     function-bind: "npm:^1.1.2"
     get-intrinsic: "npm:^1.2.4"
     globalthis: "npm:^1.0.3"
     has-property-descriptors: "npm:^1.0.2"
-    has-proto: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
     has-symbols: "npm:^1.0.3"
     internal-slot: "npm:^1.0.7"
     iterator.prototype: "npm:^1.1.2"
-    safe-array-concat: "npm:^1.1.0"
-  checksum: 10c0/d0f281257e7165f068fd4fc3beb63d07ae4f18fbef02a2bbe4a39272b764164c1ce3311ae7c5429ac30003aef290fcdf569050e4a9ba3560e044440f68e9a47c
+    safe-array-concat: "npm:^1.1.2"
+  checksum: 10c0/93be402e01fa3d8bf62fcadd2fb3055126ffcfe8846911b10b85918ef46775252696c84e6191ec8125bedb61e92242ad1a54a86118436ba19814720cb9ff4aed
   languageName: node
   linkType: hard
 
-"es-set-tostringtag@npm:^2.0.2, es-set-tostringtag@npm:^2.0.3":
+"es-set-tostringtag@npm:^2.0.3":
   version: 2.0.3
   resolution: "es-set-tostringtag@npm:2.0.3"
   dependencies:
@@ -4688,8 +4678,8 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react@npm:^7.33.2, eslint-plugin-react@npm:^7.34.0":
-  version: 7.34.0
-  resolution: "eslint-plugin-react@npm:7.34.0"
+  version: 7.34.1
+  resolution: "eslint-plugin-react@npm:7.34.1"
   dependencies:
     array-includes: "npm:^3.1.7"
     array.prototype.findlast: "npm:^1.2.4"
@@ -4711,7 +4701,7 @@ __metadata:
     string.prototype.matchall: "npm:^4.0.10"
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: 10c0/9bf0b959373ace66e799adbbfb493a7ceae54751e8f90fcce1da1a2a67b277ee23ba845571eaa4d4f05d96dba4e4977bf938b350f18bad26201fa616ee6aa4b8
+  checksum: 10c0/7c61b1314d37a4ac2f2474f9571f801f1a1a5d81dcd4abbb5d07145406518722fb792367267757ee116bde254be9753242d6b93c9619110398b3fe1746e4848c
   languageName: node
   linkType: hard
 
@@ -5063,22 +5053,22 @@ __metadata:
   linkType: hard
 
 "firebase@npm:^10.8.1":
-  version: 10.8.1
-  resolution: "firebase@npm:10.8.1"
+  version: 10.9.0
+  resolution: "firebase@npm:10.9.0"
   dependencies:
     "@firebase/analytics": "npm:0.10.1"
     "@firebase/analytics-compat": "npm:0.2.7"
-    "@firebase/app": "npm:0.9.28"
+    "@firebase/app": "npm:0.9.29"
     "@firebase/app-check": "npm:0.8.2"
     "@firebase/app-check-compat": "npm:0.3.9"
-    "@firebase/app-compat": "npm:0.2.28"
+    "@firebase/app-compat": "npm:0.2.29"
     "@firebase/app-types": "npm:0.9.0"
-    "@firebase/auth": "npm:1.6.1"
-    "@firebase/auth-compat": "npm:0.5.3"
+    "@firebase/auth": "npm:1.6.2"
+    "@firebase/auth-compat": "npm:0.5.4"
     "@firebase/database": "npm:1.0.3"
     "@firebase/database-compat": "npm:1.0.3"
-    "@firebase/firestore": "npm:4.4.3"
-    "@firebase/firestore-compat": "npm:0.3.26"
+    "@firebase/firestore": "npm:4.5.0"
+    "@firebase/firestore-compat": "npm:0.3.27"
     "@firebase/functions": "npm:0.11.2"
     "@firebase/functions-compat": "npm:0.3.8"
     "@firebase/installations": "npm:0.6.5"
@@ -5092,7 +5082,7 @@ __metadata:
     "@firebase/storage": "npm:0.12.2"
     "@firebase/storage-compat": "npm:0.3.5"
     "@firebase/util": "npm:1.9.4"
-  checksum: 10c0/662085e1e84ae0c3602eeab6b3ac929a025b07252798cb1e77b59d7471351b02c907f296c763378a58f20eca856bb05da5b4a5de40ce51a1500bf70beef6347f
+  checksum: 10c0/265b2188a2dfac5ce388e432551d9a0008136aefdeff6377185bc2027892ca6646089d4e2b7400fb6cf4ad3df8e1d06869767d2c7b959608c4041eee5a7f25fc
   languageName: node
   linkType: hard
 
@@ -5114,13 +5104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.4":
-  version: 1.15.5
-  resolution: "follow-redirects@npm:1.15.5"
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/418d71688ceaf109dfd6f85f747a0c75de30afe43a294caa211def77f02ef19865b547dfb73fde82b751e1cc507c06c754120b848fe5a7400b0a669766df7615
+  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
   languageName: node
   linkType: hard
 
@@ -6705,8 +6695,8 @@ __metadata:
   linkType: hard
 
 "msw@npm:^2.2.2":
-  version: 2.2.3
-  resolution: "msw@npm:2.2.3"
+  version: 2.2.4
+  resolution: "msw@npm:2.2.4"
   dependencies:
     "@bundled-es-modules/cookie": "npm:^2.0.0"
     "@bundled-es-modules/statuses": "npm:^1.0.1"
@@ -6732,7 +6722,7 @@ __metadata:
       optional: true
   bin:
     msw: cli/index.js
-  checksum: 10c0/ef41fefe8f95af96762206bb6f5e1e0da8022634e45f5185cccfd77bab2bd53c683c79d8274c18a1ba8085f376698dd4d8e7a8087b2142f1bb1ae88eed9f0d8c
+  checksum: 10c0/14538ba6f924cbb77807c6f13f49967699f9e588c9e2d2698dd87174d52f8bbbd49245b8894d8b3a895f5aa4601597c824a7bb625afa0cb111fcb3ad2083c90b
   languageName: node
   linkType: hard
 
@@ -7352,12 +7342,12 @@ __metadata:
   linkType: hard
 
 "postcss-selector-parser@npm:^6.0.11":
-  version: 6.0.15
-  resolution: "postcss-selector-parser@npm:6.0.15"
+  version: 6.0.16
+  resolution: "postcss-selector-parser@npm:6.0.16"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/48b425d6cef497bcf6b7d136f6fd95cfca43026955e07ec9290d3c15457de3a862dbf251dd36f42c07a0d5b5ab6f31e41acefeff02528995a989b955505e440b
+  checksum: 10c0/0e11657cb3181aaf9ff67c2e59427c4df496b4a1b6a17063fae579813f80af79d444bf38f82eeb8b15b4679653fd3089e66ef0283f9aab01874d885e6cf1d2cf
   languageName: node
   linkType: hard
 
@@ -7911,7 +7901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-array-concat@npm:^1.1.0":
+"safe-array-concat@npm:^1.1.0, safe-array-concat@npm:^1.1.2":
   version: 1.1.2
   resolution: "safe-array-concat@npm:1.1.2"
   dependencies:
@@ -8556,8 +8546,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.0.0, terser@npm:^5.26.0":
-  version: 5.29.1
-  resolution: "terser@npm:5.29.1"
+  version: 5.29.2
+  resolution: "terser@npm:5.29.2"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.8.2"
@@ -8565,7 +8555,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/5f50762d0804bf906dab4f8102811b0b94b8bceebe0f5f6186ee902200a089f06445c10f0f9bfd0cf3e118a5dd149a7cf625ec008cb880235be6901b43280833
+  checksum: 10c0/a6f1e26725e3dc99943d7173a3fca8bee21418a3ff39f37053fecd6a988b5341432d535721642807e9c24604aff64410577e9aed3200d9345c89b176b0ba3d65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📑 구현 사항

- [x] 입찰자 목록 페이지 구현
- [x] 입찰자 목록페이지 4개 API 연동 
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/bd9b7d7f-ea9b-438c-a922-be8ab0af661a)
![image](https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/6193c2a8-1ff8-4314-aa60-0d7f599b8de6)
- [x] getCookie 함수 버그 수정
- [x] auctionDetail reverse 문제 해결
- [x] authCheck 활용

## 시나리오 영상
### 1. 채팅방생성하기 - 채팅방 생성 후 자동으로 채팅방 이동

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/9cd57487-1c4d-4ef5-a5f0-3b263e5bed04


### 2.채팅하기 버튼 클릭하기 - 현재 biddingId를 이용해 채팅방 이동

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/e7c4df8b-d9c6-46b2-953f-149863922b3c


### 3. 다음 입찰자 선택하기 - 낙찰자 변경


https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/b960052f-1477-4137-841d-2f6076d8b733


### 4.거래 완료하기 - 완료 후 경매 게시글도 종료 처리 확인

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/7be83897-1e39-4ed5-834e-232b1ec6077e


## 🚧 특이 사항

- 현재는 token은 쿠키에 "token" 키 값으로 판매자 본인의 토큰을 수동으로 넣어줘야함
- 현재 로그인한 유저의 정보를 가져오는 기능이 없어서` const loginId = "10" `으로 임시 처리 함 -> 추후 변경사항
- mockservice.js를 push 한 상황 - prettier의 쌍따옴표로 인해 삽입 됨

## 📃 참고 자료

- 


## 🚨 관련 이슈

close #137 

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
