### PR TITLE
feat : 회원가입 & 온보딩 페이지 임시 합체 및 회원가입 Api 연결 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const withPWA = require("next-pwa")({
 });
 
 const nextConfig = withPWA({
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
   images: {
     domains: ["static.shoeprize.com"],

--- a/src/app/_api/imageUpload.ts
+++ b/src/app/_api/imageUpload.ts
@@ -1,7 +1,7 @@
 import { ImageUrl } from "@/utils/types/image";
 
 export const imageUpload = async (formData: FormData): Promise<ImageUrl[]> => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/images`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/images`, {
     method: "POST",
     body: formData
   });

--- a/src/app/_component/common/Reliabilitybar/index.tsx
+++ b/src/app/_component/common/Reliabilitybar/index.tsx
@@ -4,7 +4,7 @@ import { TextVariants, ThemeVariants } from "./Reliability.variants";
 
 type Theme = "default" | "main" | "terrible" | "poor" | "good";
 
-function ReliabilityBar({ score = 100 }) {
+function ReliabilityBar({ score = 100, icons_padding = 2 }) {
   const width = Math.floor(score / 2);
   const text = score === 100 ? "첫 매너 100%" : `${score}% 선해요`;
 
@@ -24,7 +24,7 @@ function ReliabilityBar({ score = 100 }) {
 
   return (
     <div>
-      <div className="flex justify-between p-2">
+      <div className={cn(`flex justify-between p-${icons_padding}`)}>
         <span>😈</span>
         <span className={cn(TextVariants({ theme }))}>{text}</span>
         <span>😇</span>

--- a/src/app/onboarding/_component/funnel/FinishFunnel.tsx
+++ b/src/app/onboarding/_component/funnel/FinishFunnel.tsx
@@ -6,9 +6,13 @@ interface FinishFunnelProps {
   category: string[];
   address: { si: string; dong: string; gu: string };
   nickName: string;
+  id: string | null;
+  passWord: string | null;
 }
 
 const FinishFunnel = ({
+  id,
+  passWord,
   profileImage,
   category,
   address,
@@ -28,6 +32,7 @@ const FinishFunnel = ({
   useEffect(() => {
     setOnboardingPost();
   }, []);
+
 
   return (
     <div>

--- a/src/app/onboarding/_component/funnel/FinishFunnel.tsx
+++ b/src/app/onboarding/_component/funnel/FinishFunnel.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { useSignUp } from "@/app/signup/_hooks/mutations/useSignup";
+
 interface FinishFunnelProps {
   profileImage: File | undefined;
   category: string[];
@@ -20,11 +22,19 @@ const FinishFunnel = ({
 }: FinishFunnelProps) => {
   const [isLoading, setIsLoading] = useState(true);
 
+  const { mutate } = useSignUp();
   const setOnboardingPost = async () => {
-    console.log(profileImage, category, address, nickName); // 추후 사용 예정
     setTimeout(() => {
-      // api 통신 예정 (profileImage  / category / address / )
-      // 통신되는 척 딜레이
+      if (id && passWord) {
+        mutate({
+          email: id,
+          password: passWord,
+          nickname: nickName,
+          profileImageUrl: "",
+          ...address,
+          productCategoryIds: category
+        });
+      }
       setIsLoading(false);
     }, 1000);
   };
@@ -32,7 +42,6 @@ const FinishFunnel = ({
   useEffect(() => {
     setOnboardingPost();
   }, []);
-
 
   return (
     <div>

--- a/src/app/onboarding/_component/funnel/FinishFunnel.tsx
+++ b/src/app/onboarding/_component/funnel/FinishFunnel.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
+import { useImageUpload } from "@/app/_hooks/mutations/useImageUpload";
 import { useSignUp } from "@/app/signup/_hooks/mutations/useSignup";
 
 interface FinishFunnelProps {
@@ -20,23 +21,34 @@ const FinishFunnel = ({
   address,
   nickName
 }: FinishFunnelProps) => {
-  const [isLoading, setIsLoading] = useState(true);
-
-  const { mutate } = useSignUp();
+  const { mutateImageUpload } = useImageUpload();
+  const { mutate, isPending } = useSignUp();
   const setOnboardingPost = async () => {
-    setTimeout(() => {
-      if (id && passWord) {
+    if (id && passWord) {
+      try {
+        const newImgForm = new FormData();
+        if (profileImage) {
+          newImgForm.append("images", profileImage);
+        }
+        const imgUrl = await mutateImageUpload(newImgForm);
+        const newArr: number[] = [];
+        category.map((item) => {
+          newArr.push(parseInt(item));
+        });
         mutate({
           email: id,
           password: passWord,
           nickname: nickName,
-          profileImageUrl: "",
-          ...address,
-          productCategoryIds: category
+          profileImageUrl: imgUrl[0],
+          si: address.si,
+          gu: address.gu,
+          dong: address.dong,
+          productCategoryIds: [...newArr]
         });
+      } catch (e) {
+        console.log(e);
       }
-      setIsLoading(false);
-    }, 1000);
+    }
   };
 
   useEffect(() => {
@@ -45,7 +57,7 @@ const FinishFunnel = ({
 
   return (
     <div>
-      {isLoading ? (
+      {isPending ? (
         <div className="flex justify-center items-center my-[8rem]">
           <div className="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-purple-500"></div>
         </div>

--- a/src/app/onboarding/_component/funnel/SelectCategory.tsx
+++ b/src/app/onboarding/_component/funnel/SelectCategory.tsx
@@ -17,19 +17,19 @@ const SelectCategory = () => {
         Items={category}
         setItems={setCategory}
         multiple>
-        <Chip value="digital-devices">디지털 기기</Chip>
-        <Chip value="furniture-interior">가구/인테리어</Chip>
-        <Chip value="fashion-accessories">패션/잡화</Chip>
-        <Chip value="home-appliances">생활가전</Chip>
-        <Chip value="home-kitchen">생활/주방</Chip>
-        <Chip value="sports-leisure">스포츠/레저</Chip>
-        <Chip value="hobby-games-music">취미/게임/음반</Chip>
-        <Chip value="beauty-care">뷰티/미용</Chip>
-        <Chip value="pet-supplies">반려동물용품</Chip>
-        <Chip value="tickets-vouchers">티켓/교환권</Chip>
-        <Chip value="books">도서</Chip>
-        <Chip value="children-books">유아도서</Chip>
-        <Chip value="other-used-items">기타중고물품</Chip>
+        <Chip value="1">디지털 기기</Chip>
+        <Chip value="2">가구/인테리어</Chip>
+        <Chip value="3">패션/잡화</Chip>
+        <Chip value="4">생활가전</Chip>
+        <Chip value="5">생활/주방</Chip>
+        <Chip value="6">스포츠/레저</Chip>
+        <Chip value="7">취미/게임/음반</Chip>
+        <Chip value="8">뷰티/미용</Chip>
+        <Chip value="9">반려동물용품</Chip>
+        <Chip value="10">티켓/교환권</Chip>
+        <Chip value="11">도서</Chip>
+        <Chip value="12">유아도서</Chip>
+        <Chip value="13">기타중고물품</Chip>
       </Chips>
       <br />
     </main>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import Toast from "../_component/common/Toast";
 import useFunnel from "../_hooks/useFunnel";
@@ -13,7 +14,11 @@ import useProfileImageStore from "./_component/store/store";
 
 const OnBoarding = () => {
   const { show } = Toast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
+  const id = searchParams.get("id");
+  const passWord = searchParams.get("password");
   const profileImage = useProfileImageStore((state) => state.profileImage);
   const category = useProfileImageStore((state) => state.category);
   const [address, setAddress] = useState({ si: "", gu: "", dong: "" });
@@ -37,9 +42,16 @@ const OnBoarding = () => {
       category={category}
       nickName={nickName}
       address={address}
+      id={id}
+      passWord={passWord}
       key="4"
     />
   ]);
+  useEffect(() => {
+    if (!id || !passWord || id?.length <= 4 || passWord?.length <= 6) {
+      router.push("/signup");
+    }
+  }, []);
 
   const onClickNextButton = () => {
     switch (topFunnelPage) {
@@ -53,7 +65,7 @@ const OnBoarding = () => {
         }
         break;
       case 1:
-        if (address.length > 0) {
+        if (address.dong) {
           pushFunnel();
         } else {
           show("거주지를 등록해주세요!", "warn-solid", 3000);

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -22,6 +22,7 @@ const OnBoarding = () => {
   const profileImage = useProfileImageStore((state) => state.profileImage);
   const category = useProfileImageStore((state) => state.category);
   const [address, setAddress] = useState({ si: "", gu: "", dong: "" });
+
   const [nickName, setNickName] = useState("");
 
   const { topComponent, topFunnelPage, pushFunnel } = useFunnel([
@@ -30,10 +31,7 @@ const OnBoarding = () => {
       key="1"
     />,
     <SelectResidence
-      setAddress={() => {
-        pushFunnel();
-        return setAddress;
-      }}
+      setAddress={setAddress}
       key="2"
     />,
     <SelectCategory key="3" />,
@@ -52,6 +50,12 @@ const OnBoarding = () => {
       router.push("/signup");
     }
   }, []);
+
+  useEffect(() => {
+    if (address.dong) {
+      pushFunnel();
+    }
+  }, [address]);
 
   const onClickNextButton = () => {
     switch (topFunnelPage) {

--- a/src/app/report/_component/CompleteReport.tsx
+++ b/src/app/report/_component/CompleteReport.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { useRouter } from "next/navigation";
+
+const CompleteReport = () => {
+  const router = useRouter();
+
+  return (
+    <div className="my-auto w-full h-full flex flex-col items-center justify-center">
+      <h1 className="text-2xl w-fit">신고 접수가 완료 되었습니다.</h1>
+      <button
+        className="my-4 w-[4rem] text-center"
+        onClick={() => router.back()}>
+        {"돌아가기"}
+      </button>
+    </div>
+  );
+};
+
+export default CompleteReport;

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import onGetImageFile from "@/utils/function/onGetImageFile";
+import tempImage from "~/images/tempImage.png";
+
+import Icon from "../_component/common/Icon";
+import Modal from "../_component/common/Modal";
+import ReliabilityBar from "../_component/common/Reliabilitybar";
+import Toast from "../_component/common/Toast";
+import UserCard from "../_component/common/UserCard";
+import CompleteReport from "./_component/CompleteReport";
+
+const TEMP_USER_DATA = {
+  profileImage: tempImage.src,
+  nickName: "닉네임#1234",
+  goodness: 140
+};
+
+const ReportPage = () => {
+  const router = useRouter();
+  const [isOpenFinishReport, setIsOpenFinishReport] = useState(false);
+  const [uploadImage, setUploadImage] = useState<File | undefined>();
+  const [reportText, setReportText] = useState<string>();
+
+  const { show } = Toast();
+
+  return (
+    <div>
+      <button
+        onClick={() => router.back()}
+        className="mt-4">
+        <Icon id="arrow-back" />
+      </button>
+      <div className="w-[85%] mx-auto flex flex-col">
+        <h1 className="text-xl mb-2">신고대상</h1>
+        <div className="bg-slate-200 rounded-md text-black">
+          <UserCard className=" mx-auto w-[92%] mt-2 mb-2 gap-3 ">
+            <UserCard.Avatar
+              size={"large"}
+              src={TEMP_USER_DATA.profileImage}
+            />
+            <UserCard.ContentArea className="w-[8rem]">
+              <p className="text-lg font-bold">{TEMP_USER_DATA.nickName}</p>
+              <ReliabilityBar
+                score={TEMP_USER_DATA.goodness}
+                icons_padding={0}
+              />
+            </UserCard.ContentArea>
+          </UserCard>
+        </div>
+        <label className="text-lg my-2">신고내용</label>
+        <div className="bg-white text-black rounded-sm">
+          <textarea
+            onChange={(event) => setReportText(event.target.value)}
+            className="px-2 py-1 w-full min-h-[21rem] mx-auto "
+          />
+        </div>
+        <button
+          className="w-full h-[3.5rem] my-2 bg-[#96E4FF] mx-auto"
+          onClick={() =>
+            onGetImageFile((newImage) => setUploadImage(newImage))
+          }>
+          {uploadImage ? (
+            <div className="flex justify-center gap-6 mr-16">
+              <Image
+                className="bg-gray-100 px-1 py-1"
+                src={URL.createObjectURL(uploadImage)}
+                width={40}
+                height={40}
+                alt="image"
+              />
+              <p className="my-auto">{"이미지 변경하기"}</p>
+            </div>
+          ) : (
+            "이미지 첨부하기"
+          )}
+        </button>
+        <button
+          onClick={() =>
+            reportText && reportText?.length > 10
+              ? setIsOpenFinishReport(true)
+              : show("최소 10글자이상 입력해주세요", "info-solid", 3000)
+          }
+          className="w-full h-[3.5rem] bg-[#96E4FF] mx-auto">
+          제출하기
+        </button>
+      </div>
+      <Modal
+        className="bg-black"
+        modalType="fullScreen"
+        animate="slide"
+        isOpen={isOpenFinishReport}
+        close={() => setIsOpenFinishReport}>
+        <CompleteReport />
+      </Modal>
+    </div>
+  );
+};
+
+export default ReportPage;

--- a/src/app/signup/_api/idDuplicateCheck.ts
+++ b/src/app/signup/_api/idDuplicateCheck.ts
@@ -1,12 +1,20 @@
-export const idDuplicateCheck = async (id: string): Promise<boolean> => {
-  const req = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/users/check-email?email=${id}`,
-    {
-      method: "GET"
-    }
-  );
-  if (req.ok) {
-    return req.ok;
+interface idDuplicateCheckProps {
+  isAvailable: boolean;
+}
+
+export const idDuplicateCheck = async (
+  id: string
+): Promise<idDuplicateCheckProps> => {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/users/check-email?email=${id}`,
+      {
+        method: "GET"
+      }
+    );
+    const result = await response.json();
+    return result;
+  } catch (e) {
+    return { isAvailable: false };
   }
-  throw new Error(req.status.toString());
 };

--- a/src/app/signup/_api/signUp.ts
+++ b/src/app/signup/_api/signUp.ts
@@ -5,7 +5,7 @@ export const signUp = async (
   authData: SignUpRequest
 ): Promise<SignUpResponse> => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/signup`,
+    `${process.env.NEXT_PUBLIC_BASE_URL}/api/users`,
     {
       method: "POST",
       headers: {

--- a/src/app/signup/_api/signUp.ts
+++ b/src/app/signup/_api/signUp.ts
@@ -1,9 +1,9 @@
-import { LoginRequest } from "@/utils/types/authorization/login";
-import { TokenResponse } from "@/utils/types/authorization/token";
+import { SignUpRequest } from "@/utils/types/user/signup";
+import { SignUpResponse } from "@/utils/types/user/signup";
 
 export const signUp = async (
-  authData: LoginRequest
-): Promise<TokenResponse> => {
+  authData: SignUpRequest
+): Promise<SignUpResponse> => {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/signup`,
     {

--- a/src/app/signup/_component/SignupForm.tsx
+++ b/src/app/signup/_component/SignupForm.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 import Input from "@/app/_component/common/Input";
@@ -16,8 +17,9 @@ type LoginFormValues = {
 
 const SignupForm = () => {
   const { show } = Toast();
+  const router = useRouter();
   const { register, handleSubmit, watch } = useForm<LoginFormValues>();
-  const [idStatus, setIdStatus] = useState<"None" | "Change" | "Ok">("Change");
+  const [idStatus, setIdStatus] = useState<"None" | "Change" | "Ok">("Ok");
   const [checkPassWord, setCheckPassWord] = useState("");
 
   const email = watch("email");
@@ -27,15 +29,18 @@ const SignupForm = () => {
 
   const signUpMutation = useSignUp();
 
-  useEffect(() => {
-    setIdStatus("Change");
-  }, [email]);
+  // useEffect(() => {
+  //   setIdStatus("Change");
+  // }, [email]);
 
-  const onSubmit = async (data: LoginFormValues) => {
+  const onSubmit = async (userAuthData: LoginFormValues) => {
     if (passWord !== checkPassWord) {
       show("비밀번호가 일치하지 않습니다", "info-solid", 3000);
     } else if (idStatus === "Ok") {
-      signUpMutation.mutate(data);
+      // signUpMutation.mutate(data);     @notice : 현재 회원가입 & 온보딩 api가 통합되어있어 분리되기전까지 회원가입 폼 전부 입력시 온보딩 페이지로 이동
+      router.push(
+        `/onboarding?id=${userAuthData.email}&password=${userAuthData.password}`
+      );
     } else {
       show("사용하실 아이디, 비밀번호를 입력해주세요", "info-solid", 3000);
     }
@@ -52,47 +57,49 @@ const SignupForm = () => {
   return (
     <div className="mx-auto w-fit mt-[8rem]">
       <form onSubmit={handleSubmit(onSubmit)}>
-        <label>아이디</label>
-        <Input className="gap-1">
-          <Input.InputInnerBox
-            className={cn(
-              getInputBorderColor(),
-              "w-[13rem] h-[2.6rem] text-black"
-            )}>
-            <Input.InputForm
-              placeholder="사용하실 아이디를 입력해주세요."
-              className="px-1 my-1 mr-1 w-[12.5rem] text-[0.85rem]"
-              {...register("email", { required: true })}
-            />
-          </Input.InputInnerBox>
-          <Input.SubmitButton
-            className="mx-2 px-1 py-[0.3rem] h-fit my-auto text-[0.75rem] bg-blue-300 rounded-md"
-            onClick={() => idDuplicateCheck.mutate(email)}>
-            중복검사
-          </Input.SubmitButton>
-        </Input>
-        <h2 className="mt-[2rem]">비밀번호</h2>
-        <Input>
-          <Input.InputInnerBox className="w-[13rem] h-[2.6rem] my-1 text-black">
-            <Input.InputForm
-              type="password"
-              placeholder="사용하실 비밀번호를 입력해주세요."
-              className="px-1 my-1 w-[12.5rem] text-[0.85rem]"
-              {...register("password", { required: true })}
-            />
-          </Input.InputInnerBox>
-        </Input>
-        <h2>비밀번호 확인</h2>
-        <Input>
-          <Input.InputInnerBox className="w-[13rem] h-[2.6rem] my-1 text-black">
-            <Input.InputForm
-              type="password"
-              placeholder="비밀번호를 다시 한번 입력해주세요."
-              className="px-1 my-1 w-[12.5rem] text-[0.85rem]"
-              onChange={(event) => setCheckPassWord(event.target.value)}
-            />
-          </Input.InputInnerBox>
-        </Input>
+        <div className="ml-4">
+          <label>아이디</label>
+          <Input className="gap-1">
+            <Input.InputInnerBox
+              className={cn(
+                getInputBorderColor(),
+                "w-[13rem] h-[2.6rem] text-black"
+              )}>
+              <Input.InputForm
+                placeholder="사용하실 아이디를 입력해주세요."
+                className="px-1 my-1 mr-1 w-[12.5rem] text-[0.85rem]"
+                {...register("email", { required: true })}
+              />
+            </Input.InputInnerBox>
+            <Input.SubmitButton
+              className="mx-2 px-1 py-[0.3rem] h-fit my-auto text-[0.75rem] bg-blue-300 rounded-md"
+              onClick={() => idDuplicateCheck.mutate(email)}>
+              중복검사
+            </Input.SubmitButton>
+          </Input>
+          <h2 className="mt-[2rem]">비밀번호</h2>
+          <Input>
+            <Input.InputInnerBox className="w-[13rem] h-[2.6rem] my-1 text-black">
+              <Input.InputForm
+                type="password"
+                placeholder="사용하실 비밀번호를 입력해주세요."
+                className="px-1 my-1 w-[12.5rem] text-[0.85rem]"
+                {...register("password", { required: true })}
+              />
+            </Input.InputInnerBox>
+          </Input>
+          <h2>비밀번호 확인</h2>
+          <Input>
+            <Input.InputInnerBox className="w-[13rem] h-[2.6rem] my-1 text-black">
+              <Input.InputForm
+                type="password"
+                placeholder="비밀번호를 다시 한번 입력해주세요."
+                className="px-1 my-1 w-[12.5rem] text-[0.85rem]"
+                onChange={(event) => setCheckPassWord(event.target.value)}
+              />
+            </Input.InputInnerBox>
+          </Input>
+        </div>
         <div className="flex gap-4 w-fit mx-auto mt-6 mb-2 ">
           <button
             type="submit"
@@ -105,7 +112,7 @@ const SignupForm = () => {
               )
             }
             className="bg-blue-200 px-2 py-1 rounded-md">
-            회원가입
+            다음으로
           </button>
         </div>
       </form>

--- a/src/app/signup/_component/SignupForm.tsx
+++ b/src/app/signup/_component/SignupForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import Input from "@/app/_component/common/Input";
@@ -8,7 +8,6 @@ import { cn } from "@/utils/function/cn";
 
 import Toast from "../../_component/common/Toast";
 import { useIdDuplicateCheck } from "../_hooks/mutations/useIdDuplicateCheck";
-import { useSignUp } from "../_hooks/mutations/useSignup";
 
 type LoginFormValues = {
   email: string;
@@ -19,7 +18,7 @@ const SignupForm = () => {
   const { show } = Toast();
   const router = useRouter();
   const { register, handleSubmit, watch } = useForm<LoginFormValues>();
-  const [idStatus, setIdStatus] = useState<"None" | "Change" | "Ok">("Ok");
+  const [idStatus, setIdStatus] = useState<"None" | "Change" | "Ok">("None");
   const [checkPassWord, setCheckPassWord] = useState("");
 
   const email = watch("email");
@@ -27,22 +26,22 @@ const SignupForm = () => {
 
   const idDuplicateCheck = useIdDuplicateCheck(setIdStatus);
 
-  const signUpMutation = useSignUp();
-
-  // useEffect(() => {
-  //   setIdStatus("Change");
-  // }, [email]);
+  useEffect(() => {
+    setIdStatus("Change");
+  }, [email]);
 
   const onSubmit = async (userAuthData: LoginFormValues) => {
-    if (passWord !== checkPassWord) {
+    if (idStatus === "None") {
+      show("이메일 중복검사를 해주세요", "info-solid", 3000);
+    } else if (email.length < 6) {
+      show("이메일을 입력해주세요.", "info-solid", 3000);
+    } else if (passWord !== checkPassWord) {
       show("비밀번호가 일치하지 않습니다", "info-solid", 3000);
     } else if (idStatus === "Ok") {
       // signUpMutation.mutate(data);     @notice : 현재 회원가입 & 온보딩 api가 통합되어있어 분리되기전까지 회원가입 폼 전부 입력시 온보딩 페이지로 이동
       router.push(
         `/onboarding?id=${userAuthData.email}&password=${userAuthData.password}`
       );
-    } else {
-      show("사용하실 아이디, 비밀번호를 입력해주세요", "info-solid", 3000);
     }
   };
   const getInputBorderColor = () => {
@@ -58,7 +57,7 @@ const SignupForm = () => {
     <div className="mx-auto w-fit mt-[8rem]">
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="ml-4">
-          <label>아이디</label>
+          <label>이메일</label>
           <Input className="gap-1">
             <Input.InputInnerBox
               className={cn(
@@ -66,6 +65,7 @@ const SignupForm = () => {
                 "w-[13rem] h-[2.6rem] text-black"
               )}>
               <Input.InputForm
+                type="email"
                 placeholder="사용하실 아이디를 입력해주세요."
                 className="px-1 my-1 mr-1 w-[12.5rem] text-[0.85rem]"
                 {...register("email", { required: true })}
@@ -103,14 +103,6 @@ const SignupForm = () => {
         <div className="flex gap-4 w-fit mx-auto mt-6 mb-2 ">
           <button
             type="submit"
-            onClick={() =>
-              idStatus !== "Ok" &&
-              show(
-                "사용하실 아이디, 비밀번호를 입력해주세요",
-                "info-solid",
-                3000
-              )
-            }
             className="bg-blue-200 px-2 py-1 rounded-md">
             다음으로
           </button>

--- a/src/app/signup/_hooks/mutations/useIdDuplicateCheck.ts
+++ b/src/app/signup/_hooks/mutations/useIdDuplicateCheck.ts
@@ -11,16 +11,16 @@ export const useIdDuplicateCheck = (
 
   return useMutation({
     mutationFn: (id: string) => idDuplicateCheck(id),
-    onSuccess: () => {
-      setIdStatus("Ok");
+    onSuccess: (data) => {
+      if (data.isAvailable) {
+        setIdStatus("Ok");
+      } else {
+        setIdStatus("None");
+        show("해당 이메일은 사용이 불가능합니다", "warn-solid", 3000);
+      }
     },
     onError: (error: Error) => {
-      switch (Number(error.message)) {
-        case 401:
-          setIdStatus("None");
-          show("중복된 아이디가 존재합니다!", "warn-solid", 2000);
-          break;
-      }
+      setIdStatus("None");
     }
   });
 };

--- a/src/app/signup/_hooks/mutations/useSignup.ts
+++ b/src/app/signup/_hooks/mutations/useSignup.ts
@@ -1,20 +1,25 @@
+"use client";
+
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import { SignUpRequest } from "@/utils/types/user/signup";
 
 import { signUp } from "../../_api/signUp";
 
 export function useSignUp() {
+  const [signupStatus, setSignupStatus] = useState("");
   const router = useRouter();
-  return useMutation({
+  const { mutate, ...rest } = useMutation({
     mutationFn: (authForm: SignUpRequest) => signUp(authForm),
-    onSuccess: (data) => {
-      console.log(data.userId);
+    onSuccess: () => {
+      setSignupStatus("success");
       router.push("/");
     },
     onError: (error: Error) => {
-      console.log(error);
+      setSignupStatus("fail");
     }
   });
+  return { signupStatus, mutate, ...rest };
 }

--- a/src/app/signup/_hooks/mutations/useSignup.ts
+++ b/src/app/signup/_hooks/mutations/useSignup.ts
@@ -1,26 +1,20 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-import Toast from "@/app/_component/common/Toast";
-import { LoginRequest } from "@/utils/types/authorization/login";
+import { SignUpRequest } from "@/utils/types/user/signup";
 
 import { signUp } from "../../_api/signUp";
 
 export function useSignUp() {
-  const { show } = Toast();
   const router = useRouter();
   return useMutation({
-    mutationFn: (authForm: LoginRequest) => signUp(authForm),
+    mutationFn: (authForm: SignUpRequest) => signUp(authForm),
     onSuccess: (data) => {
-      localStorage.setItem("AccessToken", data.accessToken);
+      console.log(data.userId);
       router.push("/");
     },
     onError: (error: Error) => {
-      switch (Number(error.message)) {
-        case 401:
-          show("아이디 또는 비밀번호가 틀렸습니다.", "warn-solid", 2000);
-          break;
-      }
+      console.log(error);
     }
   });
 }

--- a/src/utils/types/user/signup.ts
+++ b/src/utils/types/user/signup.ts
@@ -6,10 +6,9 @@ export interface SignUpRequest {
   gu: string;
   dong: string;
   profileImageUrl: string;
-  productCategoryIds: string[];
+  productCategoryIds: number[];
 }
 
 export interface SignUpResponse {
   userId: number;
 }
-


### PR DESCRIPTION
## 📑 구현 사항

- [x] 회원가입 & 온보딩 페이지 통합 Api 연결
- [x] 이메일 중복검사 API 연결
- [x] 프로필 이미지 업로드 Api 연결
- [x] 비밀번호 확인 input 추가 

## 🚧 특이 사항
### 😡 현재 인지하고 있는 **보안** 문제점
현재 `회원가입 & 온보딩 Api가 분리되어있지 않는 이슈`로  임시 배포 전까지는 회원가입 페이지 - 온보딩 페이지를 하나의 통합 Api를 사용하고 있습니다. 추후 회원가입 & 온보딩 통합 Api가 도메인별로 각각 분리 예정이며, 분리 된 api가 구현되었을 때, 빠르게 적용할 수 있도록 하기 위해 현재 존재하는 회원가입 온보딩 페이지를 유지하는 방식으로 구현했습니다.
그러다보니 현재 회원가입 페이지에서 입력 받고 온보딩 페이지로 라우팅 시킬 때, 회원가입 페이지에서 입력 받은 `데이터를 쿼리파라미터 형식으로 전달하는 방식`을 사용하고 있는데 개인정보를 쿼리 파라미터로 넘긴다면 엄청난 **보안 이슈가 있음을 인지**하고 있지만, 다음주 중으로 분리된 api가 나온다는점, 아직 실사용을 위한 배포가 아니라는점을 고려해 **임시**로 해당 방법을 사용하여 구현했습니다. 

다음주 중에  백엔드측에서 `회원가입 & 온보딩 Api 분리가 완료된다면 바로 수정겠습니다.




## 🚨 관련 이슈

close #170 

