### PR TITLE
fix: 네비게이션 스크롤 이벤트 기능 제거

### DIFF
--- a/src/app/(userpage)/layout.tsx
+++ b/src/app/(userpage)/layout.tsx
@@ -25,10 +25,7 @@ export default async function UserPageLayout({
     <section>
       <div className="px-2">{children}</div>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation
-          userId={userId}
-          initialVisible={true}
-        />
+        <Navigation userId={userId} />
       </nav>
     </section>
   );

--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import useVisibilityOnScroll from "@/app/_hooks/useVisibilityScroll";
 import { cn } from "@/utils/function/cn";
 
 import Icon from "../Icon";
@@ -16,16 +15,9 @@ interface NavigationProps {
 }
 
 const Navigation = ({ userId, initialVisible = false }: NavigationProps) => {
-  const isVisible = useVisibilityOnScroll();
   const pathname = usePathname();
   return (
-    <div
-      className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl"
-      style={{
-        transform:
-          initialVisible || isVisible ? "translateY(0)" : "translateY(200%)",
-        transition: "transform 0.3s ease-in-out"
-      }}>
+    <div className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl">
       <Link href="/home">
         <div
           className={cn(

--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -11,10 +11,9 @@ import LoginLink from "./LoginLink";
 
 interface NavigationProps {
   userId: number | undefined;
-  initialVisible?: boolean;
 }
 
-const Navigation = ({ userId, initialVisible = false }: NavigationProps) => {
+const Navigation = ({ userId }: NavigationProps) => {
   const pathname = usePathname();
   return (
     <div className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl">

--- a/src/app/_hooks/useVisibilityScroll.ts
+++ b/src/app/_hooks/useVisibilityScroll.ts
@@ -11,7 +11,10 @@ const useVisibilityOnScroll = () => {
   useEffect(() => {
     const handleScroll = throttle(() => {
       const currentScrollTop =
-        window.scrollY || document.documentElement.scrollTop;
+        window.pageYOffset ||
+        document.documentElement.scrollTop ||
+        document.body.scrollTop ||
+        0;
 
       setLastScrollTop((prevScrollTop) => {
         setIsVisible(currentScrollTop < prevScrollTop);

--- a/src/app/bookmark/layout.tsx
+++ b/src/app/bookmark/layout.tsx
@@ -25,10 +25,7 @@ export default async function UserPageLayout({
     <section>
       {children}
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation
-          userId={userId}
-          initialVisible={true}
-        />
+        <Navigation userId={userId} />
       </nav>
     </section>
   );


### PR DESCRIPTION
## 📑 구현 사항

- [x] 네비기이션 바에 적용된 스크롤 이벤트 기능 제거


## 🚧 특이 사항

- 브라우저마다 스크롤 이벤트 기능이 작동이 안되는 문제 발견
- 해결을 하려고 했지만 테스트가 불가능한 관계로 기능 삭제 결정


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #242

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
