### PR TITLE
feat: Navigation 기능 추가

### DIFF
--- a/src/app/(navigation)/layout.tsx
+++ b/src/app/(navigation)/layout.tsx
@@ -19,13 +19,11 @@ export default async function HomeLayout({
 
   const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
 
-  const userId = user ? user.userId : undefined;
-
   return (
     <section>
       {children}
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation userId={userId} />
+        <Navigation user={user} />
       </nav>
     </section>
   );

--- a/src/app/(userpage)/layout.tsx
+++ b/src/app/(userpage)/layout.tsx
@@ -19,13 +19,11 @@ export default async function UserPageLayout({
 
   const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
 
-  const userId = user ? user.userId : undefined;
-
   return (
     <section>
       <div className="px-2">{children}</div>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation userId={userId} />
+        <Navigation user={user} />
       </nav>
     </section>
   );

--- a/src/app/_api/user.ts
+++ b/src/app/_api/user.ts
@@ -1,27 +1,27 @@
 import { authCheck } from "@/utils/function/authCheck";
 import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
-export const getLoginUserInfo =
-  async (): Promise<CheckLoginUserResponse | null> => {
-    const isTokenValid = authCheck();
-    try {
-      if (!isTokenValid) throw new Error("유저 토큰이 비어있습니다.");
+export const getLoginUserInfo = async (): Promise<
+  CheckLoginUserResponse | undefined
+> => {
+  const isTokenValid = authCheck();
+  try {
+    if (!isTokenValid) throw new Error("유저 토큰이 비어있습니다.");
 
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
-        {
-          headers: {
-            Authorization: `Bearer ${isTokenValid}`
-          }
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
+      {
+        headers: {
+          Authorization: `Bearer ${isTokenValid}`
         }
-      );
-
-      if (!res.ok) {
-        throw new Error(`${res.status}`);
       }
-      return res.json();
-    } catch (error: any) {
-      console.error(error.message);
+    );
+
+    if (!res.ok) {
+      throw new Error(`${res.status}`);
     }
-    return null;
-  };
+    return res.json();
+  } catch (error: any) {
+    console.error(error.message);
+  }
+};

--- a/src/app/_component/common/Navigation/LoginLink.tsx
+++ b/src/app/_component/common/Navigation/LoginLink.tsx
@@ -20,7 +20,7 @@ const LoginLink = ({ userId, href, children }: LoginLinkProps) => {
     if (!userId) {
       e.preventDefault();
       show("로그인이 필요한 서비스입니다.", "warn-solid");
-      if (href.includes("my")) router.push("/login");
+      if (href.includes("my")) router.push("/signin");
     }
   };
 

--- a/src/app/_component/common/Navigation/LoginLink.tsx
+++ b/src/app/_component/common/Navigation/LoginLink.tsx
@@ -20,7 +20,7 @@ const LoginLink = ({ userId, href, children }: LoginLinkProps) => {
     if (!userId) {
       e.preventDefault();
       show("로그인이 필요한 서비스입니다.", "warn-solid");
-      if (href.includes("account")) router.push("/login");
+      if (href.includes("my")) router.push("/login");
     }
   };
 

--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import useSession from "@/app/_hooks/queries/useSession";
 import { cn } from "@/utils/function/cn";
 import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
@@ -17,6 +18,8 @@ interface NavigationProps {
 
 const Navigation = ({ user }: NavigationProps) => {
   const pathname = usePathname();
+  const { data: session } = useSession();
+  const userData = user || session;
 
   return (
     <div className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl">
@@ -36,7 +39,7 @@ const Navigation = ({ user }: NavigationProps) => {
         </div>
       </Link>
       <LoginLink
-        userId={user?.userId}
+        userId={userData?.userId}
         href="/chatrooms">
         <div
           className={cn(
@@ -53,7 +56,7 @@ const Navigation = ({ user }: NavigationProps) => {
       </LoginLink>
 
       <LoginLink
-        userId={user?.userId}
+        userId={userData?.userId}
         href="auctions/new">
         <div
           className={cn(
@@ -70,7 +73,7 @@ const Navigation = ({ user }: NavigationProps) => {
       </LoginLink>
 
       <LoginLink
-        userId={user?.userId}
+        userId={userData?.userId}
         href="/bookmark">
         <div
           className={cn(
@@ -86,17 +89,17 @@ const Navigation = ({ user }: NavigationProps) => {
         </div>
       </LoginLink>
       <LoginLink
-        userId={user?.userId}
+        userId={userData?.userId}
         href={"/my"}>
         <div
           className={cn(
             "flex flex-col items-center",
             `${pathname.includes("account") ? "text-[#96E4FF]" : "text-inherit"}`
           )}>
-          {user ? (
+          {userData ? (
             <div className="w-[25px] h-[25px] relative rounded-full overflow-hidden">
               <Image
-                src={user.profileImageUrl}
+                src={userData.profileImageUrl}
                 fill
                 alt="프로필이미지"
               />

--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -1,20 +1,23 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { cn } from "@/utils/function/cn";
+import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
 import Icon from "../Icon";
 import ThemeButton from "../ThemeButton";
 import LoginLink from "./LoginLink";
 
 interface NavigationProps {
-  userId: number | undefined;
+  user: CheckLoginUserResponse | undefined;
 }
 
-const Navigation = ({ userId }: NavigationProps) => {
+const Navigation = ({ user }: NavigationProps) => {
   const pathname = usePathname();
+
   return (
     <div className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl">
       <Link href="/home">
@@ -26,14 +29,14 @@ const Navigation = ({ userId }: NavigationProps) => {
           <Icon
             id="home"
             fill="none"
-            size={20}
+            size={25}
             className="hover:bg-[#72dbfe]rounded-full transition-colors"
           />
           <span className="text-[11px]">홈</span>
         </div>
       </Link>
       <LoginLink
-        userId={userId}
+        userId={user?.userId}
         href="/chatrooms">
         <div
           className={cn(
@@ -42,7 +45,7 @@ const Navigation = ({ userId }: NavigationProps) => {
           )}>
           <Icon
             id="chat-comment"
-            size={20}
+            size={25}
             className="hover:bg-[#72dbfe] rounded-full transition-colors fill-white"
           />
           <span className="text-[11px]">채팅</span>
@@ -50,7 +53,7 @@ const Navigation = ({ userId }: NavigationProps) => {
       </LoginLink>
 
       <LoginLink
-        userId={userId}
+        userId={user?.userId}
         href="auctions/new">
         <div
           className={cn(
@@ -59,7 +62,7 @@ const Navigation = ({ userId }: NavigationProps) => {
           )}>
           <Icon
             id="box-add"
-            size={20}
+            size={25}
             className="hover:bg-[#72dbfe] dark:fill-white rounded-full transition-colors fill-black"
           />
           <span className="text-[11px]">경매 등록</span>
@@ -67,7 +70,7 @@ const Navigation = ({ userId }: NavigationProps) => {
       </LoginLink>
 
       <LoginLink
-        userId={userId}
+        userId={user?.userId}
         href="/bookmark">
         <div
           className={cn(
@@ -76,25 +79,36 @@ const Navigation = ({ userId }: NavigationProps) => {
           )}>
           <Icon
             id="bookmark-fill-none"
-            size={20}
+            size={25}
             className="hover:bg-[#72dbfe]  rounded-full transition-colors"
           />
           <span className="text-[11px]">북마크</span>
         </div>
       </LoginLink>
       <LoginLink
-        userId={userId}
+        userId={user?.userId}
         href={"/my"}>
         <div
           className={cn(
             "flex flex-col items-center",
             `${pathname.includes("account") ? "text-[#96E4FF]" : "text-inherit"}`
           )}>
-          <Icon
-            id="user-alt-fill"
-            size={20}
-            className="hover:bg-[#72dbfe] rounded-full transition-colors fill-black"
-          />
+          {user ? (
+            <div className="w-[25px] h-[25px] relative rounded-full overflow-hidden">
+              <Image
+                src={user.profileImageUrl}
+                fill
+                alt="프로필이미지"
+              />
+            </div>
+          ) : (
+            <Icon
+              id="user-alt-fill"
+              size={25}
+              className="hover:bg-[#72dbfe] rounded-full transition-colors fill-black"
+            />
+          )}
+
           <span className="text-[11px]">마이페이지</span>
         </div>
       </LoginLink>

--- a/src/app/bookmark/layout.tsx
+++ b/src/app/bookmark/layout.tsx
@@ -19,13 +19,11 @@ export default async function UserPageLayout({
 
   const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
 
-  const userId = user ? user.userId : undefined;
-
   return (
     <section>
       {children}
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation userId={userId} />
+        <Navigation user={user} />
       </nav>
     </section>
   );

--- a/src/app/chatrooms/page.tsx
+++ b/src/app/chatrooms/page.tsx
@@ -5,11 +5,19 @@ import { Suspense } from "react";
 import ArrowBackButton from "../_component/common/ArrowBackButton";
 import Header from "../_component/common/Header";
 import Navigation from "../_component/common/Navigation";
+import Spinner from "../_component/common/Spinner";
 import useSession from "../_hooks/queries/useSession";
 import ChatRoomList from "./_component/ChatRoomList";
 
 const ChatRooms = () => {
-  const { data: user } = useSession();
+  const { data: user, isLoading } = useSession();
+
+  if (isLoading)
+    return (
+      <div>
+        <Spinner />
+      </div>
+    );
 
   return (
     <>
@@ -27,7 +35,7 @@ const ChatRooms = () => {
         </Suspense>
       </section>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation userId={user?.userId} />
+        <Navigation user={user} />
       </nav>
     </>
   );


### PR DESCRIPTION
## 📑 구현 사항

- [x] 로그인 시 Navigation 에 자신의 프로필이 보이도록 기능 추가
- [x] getLoginUserInfo API 호출 함수 반환 타입 수정 -> useSession에 관련된 함수

### 로그인 전
https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/ce598529-2633-4204-8d69-47605f46cfcc

### 로그인 후

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/90139306/58a490f2-ad4d-4c11-8e23-3c65da775907



## 🚧 특이 사항

- getLoginUserInfo의 반환타입을 `<CheckLoginUserResponse | undefined> ` 로 바꿈
- Navigaion 사용하는 부분 props 모두 수정
- 로그인시 바로 반영되도록 Navigtion내에서 useSession 요청

## 📃 참고 자료

- 


## 🚨 관련 이슈

close #241 

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
