### PR TITLE
feat: 스플래시 화면 구현

### DIFF
--- a/src/app/_component/common/Splash/index.tsx
+++ b/src/app/_component/common/Splash/index.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+function Splash() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.push("/home");
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <main className="flex flex-col justify-center items-center h-dvh">
+      <div className="text-center">
+        <p className="text-xl mb-4">경매로 진행하는 중고 물품 거래</p>
+        <Image
+          src="/assets/images/textLogo.webp"
+          width={250}
+          height={100}
+          alt="textLogo-handsup"
+        />
+      </div>
+      <div className="fixed bottom-0 left-1/2 transform -translate-x-1/2">
+        <Image
+          src="/assets/images/hans.webp"
+          width={300}
+          height={200}
+          alt="로고"
+        />
+      </div>
+    </main>
+  );
+}
+
+export default Splash;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
+import Splash from "./_component/common/Splash";
+
 export default function Home() {
-  return (
-    <main className="">
-    </main>
-  );
+  return <Splash />;
 }


### PR DESCRIPTION
## 📑 구현 사항

- [x] 스플래시 화면 구현
- [x] / -> /home으로 페이지 이동

https://github.com/Programmers-HandsUp/FE-HandsUp/assets/93479475/5f005612-5371-4911-853b-2db51f2f8380



## 🚧 특이 사항

- 어제 화면 공유했던 것처럼 애니메이션이 있는 스플래시를 사용할 경우 홈페이지에서 경매 관련 로딩이 한번 더 나와 스플래시화면에서는 애니메이션을 사용하지않았습니다! 


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #이슈번호

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
