### PR TITLE
fix : 검색결과 페이지 bookmarkCount 제대로 표기 안되는 버그 수정

### DIFF
--- a/src/app/search/[searchString]/page.tsx
+++ b/src/app/search/[searchString]/page.tsx
@@ -41,7 +41,8 @@ const SearchResultPage = () => {
               currentBiddingPrice,
               dong,
               imageUrl,
-              createdAt
+              createdAt,
+              bookmarkCount
             }: AuctionSearchResult) => (
               <div key={auctionId}>
                 <ProductCard
@@ -68,7 +69,7 @@ const SearchResultPage = () => {
                           className="h-fit mr-1 mt-1"
                           id="bookmark-fill"
                         />
-                        <span className="text-[1rem]">10</span>
+                        <span className="text-[1rem]">{bookmarkCount}</span>
                       </div>
                     </div>
                   </ProductCard.CardTitle>


### PR DESCRIPTION
## 📑 구현 사항

### 검색결과 페이지 bookmarkCount 제대로 표기 안되는 버그 수정
원인 : Api로 받아온 값을 출력하는게 아닌, 초기에 디자인용으로 기입해둔 상수 값으로 출력 되고 있었습니다.

## 🚨 관련 이슈

close #255

