### PR TITLE
fix: 입찰 목록페이지 버그 수정

### DIFF
--- a/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_api/getChatRoomInfo.ts
@@ -5,9 +5,9 @@ const getChatRoomInfo = async ({
   biddingId
 }: {
   biddingId: number | undefined;
-}): Promise<ChatRoomInfoResponse> => {
+}): Promise<ChatRoomInfoResponse | undefined> => {
   if (biddingId === undefined) {
-    throw new Error("400");
+    return undefined;
   }
 
   const isTokenValid = authCheck();
@@ -15,7 +15,6 @@ const getChatRoomInfo = async ({
   if (!isTokenValid) {
     throw new Error("401");
   }
-
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/chat-rooms/biddings/${biddingId}`,
     {

--- a/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/_component/BidderStatusItem/index.tsx
@@ -13,12 +13,14 @@ export interface BidderStatusItemProps {
   createChatRoom: ({ biddingId }: { biddingId: number }) => void;
   patchComplete: () => void;
   patchCompleteIsLoading: boolean;
+  userId: number;
 }
 
 const BidderStatusItem = ({
   profileImage,
   nickName,
   biddingId,
+  userId,
   chatRoomId,
   biddingPrice,
   status,
@@ -47,7 +49,7 @@ const BidderStatusItem = ({
           return (
             <div className="flex gap-2">
               <Link
-                href={`/chatrooms/${chatRoomId}`}
+                href={`/chatrooms/${chatRoomId}/?senderId=${userId}`}
                 className={`${baseClass} ${hoverClass}`}>
                 채팅하기
               </Link>

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useCreateChatRoom.ts
@@ -5,7 +5,13 @@ import Toast from "@/app/_component/common/Toast";
 
 import createChatRoom from "../_api/createChatRoom";
 
-const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
+const useCreateChatRoom = ({
+  auctionId,
+  userId
+}: {
+  auctionId: number;
+  userId: number | undefined;
+}) => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const toast = Toast();
@@ -14,7 +20,7 @@ const useCreateChatRoom = ({ auctionId }: { auctionId: number }) => {
     mutationFn: ({ biddingId }: { biddingId: number }) =>
       createChatRoom({ auctionId, biddingId }),
     onSuccess: (data) => {
-      router.push(`/chatrooms/${data.chatRoomId}`);
+      router.push(`/chatrooms/${data.chatRoomId}/?senderId=${userId}`);
       queryClient.invalidateQueries({
         queryKey: ["auction", auctionId, "bids"]
       });

--- a/src/app/auctions/[auctionId]/bidderList/_hooks/useGetChatRoomInfo.ts
+++ b/src/app/auctions/[auctionId]/bidderList/_hooks/useGetChatRoomInfo.ts
@@ -11,8 +11,7 @@ const useGetChatRoomInfo = ({
 }) => {
   const { data, refetch, isLoading } = useQuery({
     queryKey: ["chat", "chat-room-info"],
-    queryFn: () => getChatRoomInfo({ biddingId }),
-    enabled: biddingId !== undefined
+    queryFn: () => getChatRoomInfo({ biddingId })
   });
 
   return { data, refetch, isLoading };

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
 
 import useSession from "@/app/_hooks/queries/useSession";
 
@@ -26,6 +27,12 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
 
   const { data: user, isLoading: userLoading } = useSession();
 
+  const queryClient = useQueryClient();
+
+  const invalidateChatRoomInfo = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["chat", "chat-room-info"] });
+  }, [queryClient]);
+
   const {
     data: bidsData,
     isLoading: bidsDataLoading,
@@ -49,6 +56,10 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   const { mutation: createChatRoomMutation } = useCreateChatRoom({
     auctionId: numberOfAuctionId
   });
+
+  useEffect(() => {
+    invalidateChatRoomInfo();
+  }, [invalidateChatRoomInfo]);
 
   useEffect(() => {
     setProgressingBiddingId(

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -59,7 +59,7 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
 
   useEffect(() => {
     invalidateChatRoomInfo();
-  }, [invalidateChatRoomInfo]);
+  }, [invalidateChatRoomInfo, progressingBiddingId]);
 
   useEffect(() => {
     setProgressingBiddingId(
@@ -72,7 +72,7 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   if (bidsDataError) return <div>에러가 발생했어요.</div>;
   if (!bidsData) return <div>입찰자가 없어요.</div>;
   if (!user) return <div>로그인을 해주세요.</div>;
-
+  console.log(user.userId);
   return (
     <main className="">
       {bidsData.content.map((data) => (
@@ -82,6 +82,7 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
           profileImage={data.imgUrl}
           biddingPrice={data.biddingPrice}
           nickName={data.bidderNickname}
+          userId={user.userId}
           status={data.tradingStatus}
           isSeller={Number(sellerId) === user.userId}
           chatRoomId={chatRoomInfo?.chatRoomId}

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -60,9 +60,8 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
     return <div>Loading...</div>;
   if (bidsDataError) return <div>에러가 발생했어요.</div>;
   if (!bidsData) return <div>입찰자가 없어요.</div>;
-  if (!chatRoomInfo) return <div>채팅방을 가져올 수 없어요.</div>;
   if (!user) return <div>로그인을 해주세요.</div>;
-
+  console.log(chatRoomInfo);
   return (
     <main className="">
       {bidsData.content.map((data) => (

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -61,7 +61,7 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
   if (bidsDataError) return <div>에러가 발생했어요.</div>;
   if (!bidsData) return <div>입찰자가 없어요.</div>;
   if (!user) return <div>로그인을 해주세요.</div>;
-  console.log(chatRoomInfo);
+
   return (
     <main className="">
       {bidsData.content.map((data) => (

--- a/src/app/auctions/[auctionId]/bidderList/page.tsx
+++ b/src/app/auctions/[auctionId]/bidderList/page.tsx
@@ -54,7 +54,8 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
     biddingId: progressingBiddingId
   });
   const { mutation: createChatRoomMutation } = useCreateChatRoom({
-    auctionId: numberOfAuctionId
+    auctionId: numberOfAuctionId,
+    userId: user?.userId
   });
 
   useEffect(() => {
@@ -65,14 +66,15 @@ const BidderListPage = ({ params, searchParams }: BidderListPageProps) => {
     setProgressingBiddingId(
       bidsData?.content.find((x) => x.tradingStatus === "진행중")?.biddingId
     );
-  }, [bidsData]);
+    invalidateChatRoomInfo();
+  }, [bidsData, invalidateChatRoomInfo]);
 
   if (bidsDataLoading || userLoading || chatRoomInfoLoading)
     return <div>Loading...</div>;
   if (bidsDataError) return <div>에러가 발생했어요.</div>;
   if (!bidsData) return <div>입찰자가 없어요.</div>;
-  if (!user) return <div>로그인을 해주세요.</div>;
-  console.log(user.userId);
+  if (!user) return <div>다시 로그인을 해주세요.</div>;
+
   return (
     <main className="">
       {bidsData.content.map((data) => (

--- a/src/app/chatrooms/[chatRoomId]/_component/ChatRoomContent.tsx
+++ b/src/app/chatrooms/[chatRoomId]/_component/ChatRoomContent.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import ChatMessage from "@/app/_component/common/ChatMessage";
@@ -31,6 +31,8 @@ const ChatRoomContent = ({
     hasNextPage
   } = useGetChatData({ chatRoomId });
   const router = useRouter();
+
+  const searchParams = useSearchParams();
 
   const { data: currentUser, isLoading: userLoading } = useSession();
 
@@ -85,8 +87,7 @@ const ChatRoomContent = ({
     router.back();
     return null;
   }
-
-  const senderId = currentUser.userId;
+  const senderId = Number(searchParams.get("senderId"));
 
   const onSubmit = (data: FormDataType) => {
     sendMessage({

--- a/src/app/chatrooms/[chatRoomId]/_component/ChatRoomInfoHeader.tsx
+++ b/src/app/chatrooms/[chatRoomId]/_component/ChatRoomInfoHeader.tsx
@@ -39,7 +39,7 @@ const ChatRoomInfoHeader = ({ chatRoomId }: ChatRoomInfoHeaderProps) => {
         <ProductCard id={data.auctionId}>
           <div className="overflow-hidden rounded-xl">
             <ProductCard.CardImage
-              titleImage="https://cdn.eyesmag.com/content/uploads/sliderImages/2020/12/24/air-jordan-1-ko-chicago-01-406abe1e-0ef2-4b71-b479-7716fdb60630.jpg"
+              titleImage={data.auctionImageUrl}
               width={50}
               height={50}
             />

--- a/src/app/chatrooms/[chatRoomId]/page.tsx
+++ b/src/app/chatrooms/[chatRoomId]/page.tsx
@@ -6,6 +6,7 @@ import ChatRoomInfoHeader from "./_component/ChatRoomInfoHeader";
 
 const ChatRoomPage = () => {
   const params = useParams<{ chatRoomId: string }>();
+
   return (
     <section>
       <ChatRoomInfoHeader chatRoomId={Number(params.chatRoomId)} />

--- a/src/app/chatrooms/_component/ChatRoomList.tsx
+++ b/src/app/chatrooms/_component/ChatRoomList.tsx
@@ -5,7 +5,11 @@ import Icon from "@/app/_component/common/Icon";
 
 import useGetChatRooms from "../_hooks/queries/useGetChatRooms";
 
-const ChatRoomList = () => {
+interface ChatRoomListProps {
+  userId: number;
+}
+
+const ChatRoomList = ({ userId }: ChatRoomListProps) => {
   const { data } = useGetChatRooms();
 
   return (
@@ -30,7 +34,7 @@ const ChatRoomList = () => {
             </span>
             <div className="absolute right-5 opacity-0 group-hover:opacity-90 transition-opacity text-white">
               <Link
-                href={`/chatrooms/${content.chatRoomId}`}
+                href={`/chatrooms/${content.chatRoomId}?senderId=${userId}`}
                 className="hover:text-[#96E4ff] px-2 rounded-xl">
                 <Icon id="arrow-right" />
               </Link>

--- a/src/app/chatrooms/page.tsx
+++ b/src/app/chatrooms/page.tsx
@@ -18,7 +18,7 @@ const ChatRooms = () => {
         <Spinner />
       </div>
     );
-
+  if (!user) return <div>다시 로그인을 해주세요.</div>;
   return (
     <>
       <Header
@@ -31,7 +31,7 @@ const ChatRooms = () => {
       />
       <section>
         <Suspense fallback={<div>Loading...</div>}>
-          <ChatRoomList />
+          <ChatRoomList userId={user?.userId} />
         </Suspense>
       </section>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">

--- a/src/utils/types/chat/checkChatRoomInfrom.ts
+++ b/src/utils/types/chat/checkChatRoomInfrom.ts
@@ -3,6 +3,7 @@ export interface ChatRoomInfoResponse {
   auctionId: number;
   currentBiddingId: number;
   currentBiddingPrice: number;
+  auctionImageUrl: string;
   tradingStatus: "대기중" | "준비중" | "진행중" | "취소됨" | "완료됨";
   auctionTitle: string;
   receiverId: number;


### PR DESCRIPTION
## 📑 구현 사항

- [x] `getChatRoomInfo`에서 존재했던 버그 수정
- [x] 유동적으로 바뀌는 `biddingId`가 캐싱되어서 고정되는 문제 처리
- [x] `chatrooms/:chatRoomId`에서 `chatrooms/:chatRoomId?senderId=${senderId}`로 변경
- [x] `ChatRoomInfoResponse `타입에 `auctionImageUrl `데이터 추가로 인해 변경

## 🚧 특이 사항

- `getChatRoomInfo`는 "진행중" 입찰 데이터에 따라서 데이터를 가져와야했음
- 근데 `useQuery`의 `enabled`로 처음부터 막아버림 - > 이 문제로 입찰 목록 페이지는 예외처리 문이 출력되어버림
- 해당 부분을 `biddingId`가 없으면 `undefined`로 반환하도록 수정하고 `undefined`일 때도 정상적으로 시나리오가 진행되도록 수정 함
- chatrooms/:chatRoomId에서 쿼리 `senderId`를 고정한 이유는 웹소켓 기능 중에 만약 `user`의 정보가 `stale `상태가 되면 `senderId`가 없어지는 타이밍이 생겨서 웹소켓에서 senderId를 못받게 되고 에러를 발생시킨다.
 -> 그래서 `senderId`를 고정시키기위해 쿼리에 senderId를 고정시켰다.



## 📃 참고 자료

- 


## 🚨 관련 이슈

close #257

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
