### PR TITLE
fix: 로그인 시 알림설정 팝업 뜨도록 변경

### DIFF
--- a/src/app/(navigation)/home/_api/getAuctionRecommends.ts
+++ b/src/app/(navigation)/home/_api/getAuctionRecommends.ts
@@ -1,4 +1,4 @@
-import { fetchWithTokenRenewal } from "@/utils/function/fetchWithTokenRenewal";
+import { authCheck } from "@/utils/function/authCheck";
 import { RecommendAuctionsResponse } from "@/utils/types/auction/recommendAuction";
 
 import { AddressState } from "../_component/MainContentSection";
@@ -86,11 +86,18 @@ export async function getSortedBids({
 
 export async function getSortedCategory(): Promise<RecommendAuctionsResponse | null> {
   try {
-    const res = await fetchWithTokenRenewal(
+    const accessToken = authCheck();
+
+    if (!accessToken) return null;
+
+    const res = await fetch(
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/recommend/category?&page=0&size=10&sort=북마크수`,
       {
         next: {
           tags: ["auction", "bids"]
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`
         },
         cache: "no-store"
       }

--- a/src/app/_api/bookmark.ts
+++ b/src/app/_api/bookmark.ts
@@ -1,5 +1,4 @@
 import { authCheck } from "@/utils/function/authCheck";
-import { fetchWithTokenRenewal } from "@/utils/function/fetchWithTokenRenewal";
 import { BookMarkedAddResponse } from "@/utils/types/bookmark/add";
 import { BookMarkedAllCheckResponse } from "@/utils/types/bookmark/allCheck";
 import { BookMarkedDeleteResponse } from "@/utils/types/bookmark/delete";
@@ -11,12 +10,19 @@ export type getCheckBookmarkResponse = { isBookmarked: boolean };
 export const getCheckBookmark = async ({
   auctionId
 }: getCheckBookmarkParams): Promise<getCheckBookmarkResponse | null> => {
-  const res = await fetchWithTokenRenewal(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bookmarks/${auctionId}`
+  const isTokenValid = authCheck();
+
+  if (!isTokenValid) return null;
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bookmarks/${auctionId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${isTokenValid}`
+      }
+    }
   );
-  if (res === null) {
-    return null;
-  }
+
   if (!res.ok) {
     throw new Error("서버 에러 발생");
   }
@@ -75,12 +81,14 @@ export const deleteBookmark = async (
 
 export const getCheckBookmarkList =
   async (): Promise<BookMarkedAllCheckResponse | null> => {
-    const res = await fetchWithTokenRenewal(
+    const isTokenValid = authCheck();
+
+    if (!isTokenValid) return null;
+
+    const res = await fetch(
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/bookmarks`
     );
-    if (res === null) {
-      return null;
-    }
+
     if (!res.ok) {
       throw new Error("서버 에러 발생");
     }

--- a/src/app/_api/user.ts
+++ b/src/app/_api/user.ts
@@ -1,27 +1,27 @@
 import { authCheck } from "@/utils/function/authCheck";
 import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
-export const getLoginUserInfo = async (): Promise<
-  CheckLoginUserResponse | undefined
-> => {
-  const isTokenValid = authCheck();
-  try {
-    if (!isTokenValid) throw new Error("유저 토큰이 비어있습니다.");
+export const getLoginUserInfo =
+  async (): Promise<CheckLoginUserResponse | null> => {
+    const isTokenValid = authCheck();
+    try {
+      if (!isTokenValid) throw new Error("유저 토큰이 비어있습니다.");
 
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
-      {
-        headers: {
-          Authorization: `Bearer ${isTokenValid}`
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
+        {
+          headers: {
+            Authorization: `Bearer ${isTokenValid}`
+          }
         }
-      }
-    );
+      );
 
-    if (!res.ok) {
-      throw new Error(`${res.status}`);
+      if (!res.ok) {
+        throw new Error(`${res.status}`);
+      }
+      return res.json();
+    } catch (error: any) {
+      console.error(error.message);
     }
-    return res.json();
-  } catch (error: any) {
-    console.error(error.message);
-  }
-};
+    return null;
+  };

--- a/src/app/auctions/[auctionId]/_api/createComment.ts
+++ b/src/app/auctions/[auctionId]/_api/createComment.ts
@@ -1,4 +1,4 @@
-import { fetchWithTokenRenewal } from "@/utils/function/fetchWithTokenRenewal";
+import { authCheck } from "@/utils/function/authCheck";
 
 export interface CreateCommentRequest {
   content: string;
@@ -9,12 +9,15 @@ export const createComment = async ({
   content,
   auctionId
 }: CreateCommentRequest) => {
-  await fetchWithTokenRenewal(
+  const accessToken = authCheck();
+
+  await fetch(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auctions/${auctionId}/comments`,
     {
       method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`
       },
       body: JSON.stringify({
         content

--- a/src/app/signin/_hooks/mutations/redirectActionsHome.ts
+++ b/src/app/signin/_hooks/mutations/redirectActionsHome.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export async function navigate() {
+  redirect("/home");
+}

--- a/src/app/signin/_hooks/mutations/useSignin.ts
+++ b/src/app/signin/_hooks/mutations/useSignin.ts
@@ -1,21 +1,21 @@
 import { useMutation } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 
 import Toast from "@/app/_component/common/Toast";
 import { setCookie } from "@/utils/function/cookie";
 import { LoginRequest } from "@/utils/types/authorization/login";
 
 import { signIn } from "../../_api/login";
+import { navigate } from "./redirectActionsHome";
 
 export function useSignIn() {
   const { show } = Toast();
-  const router = useRouter();
+
   return useMutation({
     mutationFn: (authForm: LoginRequest) => signIn(authForm),
     onSuccess: (data) => {
       setCookie({ name: "accessToken", value: data.accessToken });
       show("로그인 성공했습니다", "check-solid", 2000);
-      router.push("/home");
+      navigate();
     },
     onError: () => {
       show("로그인 실패했습니다", "warn-solid", 2000);


### PR DESCRIPTION
## 📑 구현 사항

- [x] 로그인 시 알림설정 팝업이 안 뜨는 문제 해결
- [x] FCM토큰이 없을 때 모든 API요청이 오류 뜨는 문제 임시 제거


## 🚧 특이 사항

- 로그인 후 `router.push`가 아닌 `redirect` 이용 - > 서버에서 라우팅되어야 알림 설정 팝업이 뜸
- FCM 토큰관련 에러가 뜨면 `fetchwithTokenRenewal` 함수가 에러를 받고 쿠키에 저장된 `accessToken`을 `undefined`로 만드는 문제가 생김
- 일단 FCM오류가 생겨도 accessToken을 건들지 않도록 `fetchwithTokenRenewal` 함수 사용 부분 제거


## 📃 참고 자료

- 


## 🚨 관련 이슈

close #262

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
