### PR TITLE
fix : 검색 필터 다크모드 적용 안됐을 때 디자인 이상해지는 버그 수정

### DIFF
--- a/src/app/search/[searchString]/_component/SearchFilter.tsx
+++ b/src/app/search/[searchString]/_component/SearchFilter.tsx
@@ -36,7 +36,7 @@ const SearchFilterModal = ({
   const [isShowCategory, setIsShowCategory] = useState(true);
   const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
   return (
-    <div>
+    <div className="pl-2">
       <button
         className="flex text-2xl my-1"
         onClick={() => setIsShowCategory((isShow) => !isShow)}>
@@ -49,7 +49,7 @@ const SearchFilterModal = ({
       </button>
       {isShowCategory && (
         <Chips
-          className="grid grid-cols-2"
+          className="grid grid-cols-2 px-3"
           Items={selectedCategory}
           setItems={(items: string[]) => {
             setSelectedCategory(items);
@@ -66,7 +66,7 @@ const SearchFilterModal = ({
         </Chips>
       )}
       <h2 className="text-2xl mt-4">거래 방식</h2>
-      <div className="flex gap-[6.7rem] my-3 px-2">
+      <div className="flex gap-[6.7rem] my-3 px-3">
         <div>
           <input
             className="mr-2 w-4 h-4 text-[#96E4FF] bg-gray-100 border-gray-300 focus:ring-[#96E4FF] dark:focus:text-[#96E4FF] dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
@@ -88,7 +88,7 @@ const SearchFilterModal = ({
           <label>택배</label>
         </div>
       </div>
-      <div className="flex gap-[5rem] px-2">
+      <div className="flex gap-[5rem] px-3">
         <div>
           <input
             type="checkbox"
@@ -103,11 +103,11 @@ const SearchFilterModal = ({
             className="mr-2"
             {...register("isProgress")}
           />
-          <label>진행 중인 경매만 보기</label>
+          <label className="text-[0.9rem]">진행 중인 경매만 보기</label>
         </div>
       </div>
       <h2 className="mt-4 text-xl">금액</h2>
-      <div className="px-1">
+      <div className="px-3">
         <Input className="my-1">
           <label className="my-auto mr-4 text-lg">이상</label>
           <Input.InputInnerBox className="w-[14rem] h-[2.8rem]">

--- a/src/app/search/[searchString]/layout.tsx
+++ b/src/app/search/[searchString]/layout.tsx
@@ -39,7 +39,7 @@ export default function MainPageLayout({
         </header>
         {children}
         <Modal
-          className="bg-black"
+          className="dark:bg-black"
           modalType="fullScreen"
           animate="slide"
           isOpen={isOpen}


### PR DESCRIPTION
## 📑 구현 사항

* 검색 필터 다크모드 적용 안됐을 때 디자인 이상해지는 버그 수정
* 검색 필터 버튼 간격 미세하게 수정

#### 수정 전 / 수정 후
<img width="300" src="https://github.com/Programmers-HandsUp/FE-HandsUp/assets/40955023/707324a8-e8ce-4716-a423-6a1eb8d1c910">

<img width="300" alt="image" src="https://github.com/Programmers-HandsUp/FE-HandsUp/assets/40955023/8be1380f-451a-4379-8055-c5afdb5d7431">


## 🚨 관련 이슈

close #267

