### PR TITLE
fix: 토큰이 쿠키에 존재하지 않을 경우 알림 관련 data fetching이 안되도록 수정 

### DIFF
--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -57,7 +57,7 @@ const Navigation = ({ user }: NavigationProps) => {
 
       <LoginLink
         userId={userData?.userId}
-        href="auctions/new">
+        href="/auctions/new">
         <div
           className={cn(
             "flex flex-col items-center",

--- a/src/app/_component/notification/_api/notification.ts
+++ b/src/app/_component/notification/_api/notification.ts
@@ -22,8 +22,6 @@ export const sendFCMToken = async (fcmToken: string) => {
     const errData = await res.json();
     throw new Error(errData.message);
   }
-
-  return res.json();
 };
 
 export const notificationList = async ({

--- a/src/app/_component/notification/_api/notification.ts
+++ b/src/app/_component/notification/_api/notification.ts
@@ -4,8 +4,6 @@ import { Notifications } from "@/utils/types/notification";
 export const sendFCMToken = async (fcmToken: string) => {
   const isTokenValid = authCheck();
 
-  if (!isTokenValid) return "";
-
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/notifications/fcm-tokens`,
     {
@@ -35,8 +33,6 @@ export const notificationList = async ({
 }): Promise<Notifications> => {
   const isTokenValid = authCheck();
 
-  if (!isTokenValid) return { content: [], size: 0, hasNext: false };
-
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/notifications?page=${pageParam}&size=10`,
     {
@@ -56,7 +52,6 @@ export const notificationList = async ({
 export const notificationBadge = async (): Promise<{ count: number }> => {
   const isTokenValid = authCheck();
 
-  if (!isTokenValid) return { count: 0 };
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}/api/notifications/count`,
     {

--- a/src/app/_component/notification/_component/NotificationList.tsx
+++ b/src/app/_component/notification/_component/NotificationList.tsx
@@ -10,12 +10,10 @@ function NotificationList() {
     data: notifications,
     fetchNextPage,
     hasNextPage,
-    isError,
-
     isFetched
   } = useNotificationList();
 
-  const { data: isRead, isError: badgeError } = useNotificationBadge();
+  const { data: isRead } = useNotificationBadge();
 
   const refetch = () => {
     if (hasNextPage && isFetched) fetchNextPage();
@@ -26,8 +24,6 @@ function NotificationList() {
   if (notifications.length === 0) {
     return <EmptyNotification />;
   }
-
-  if (isError || badgeError) return <div>에러</div>;
 
   return (
     <>

--- a/src/app/_component/notification/index.tsx
+++ b/src/app/_component/notification/index.tsx
@@ -2,6 +2,8 @@
 
 import { Suspense } from "react";
 
+import { authCheck } from "@/utils/function/authCheck";
+
 import Header from "../common/Header";
 import Icon from "../common/Icon";
 import Loading from "../common/Loading";
@@ -13,6 +15,8 @@ interface NotificationProps {
 }
 
 function Notification({ close }: NotificationProps) {
+  const auth = authCheck();
+
   return (
     <>
       <Header
@@ -25,15 +29,17 @@ function Notification({ close }: NotificationProps) {
           </div>
         }
       />
+      {auth && (
+        <>
+          <CheckPermission />
 
-      <CheckPermission />
- 
-        <Suspense fallback={<Loading />}>
-          <div className="px-2 w-full max-w-screen mx-auto mt-4">
-            <NotificationList />
-          </div>
-        </Suspense>
-
+          <Suspense fallback={<Loading />}>
+            <div className="px-2 w-full max-w-screen mx-auto mt-4">
+              <NotificationList />
+            </div>
+          </Suspense>
+        </>
+      )}
     </>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,17 +1,14 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { getLoginUserInfo } from "./app/_api/user";
-
-// This function can be marked `async` if using `await` inside
 export async function middleware(request: NextRequest) {
-  const auth = await getLoginUserInfo();
-  if (!auth) {
+  const cookie = request.cookies.get("accessToken");
+
+  if (!cookie) {
     return NextResponse.redirect(new URL("/signin", request.url));
   }
 }
 
-// See "Matching Paths" below to learn more
 export const config = {
   matcher: [
     "/notification",


### PR DESCRIPTION
## 📑 구현 사항

- 쿠키에 토큰이 존재하지 않을 경우 알림 관련 data fetching이 안되로록 수정했습니다.
- 이전 토큰이 없는 경우 반환했던 빈 데이터들은 삭제했습니다. 
- 미들웨어에서 `getUserInfo` 데이터의 존재 여부를 통해 라우터를 설정하는 방식이 아닌, 불필요한 데이터 페칭을 줄이기 위해 수정하였습니다. 쿠키에 `accessToken`이 존재하지 않는 경우에만 로그인 페이지로 이동하도록 변경했습니다. 
- 네비게이션 경매 등록 Link href에 / 추가했습니다. 

## 🚧 특이 사항

## 📃 참고 자료

## 🚨 관련 이슈

#282

## ✅ 리뷰 반영 사항

- [ ] 리뷰 반영 사항 작성
