### PR TITLE
refactor : 사용자 정보 관련 Api 호출 방식 변경 및 MSW 서버 모킹 환경 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ const nextConfig = withPWA({
   images: {
     domains: ["static.shoeprize.com"],
     unoptimized: true
+  },
+  experimental: {
+    instrumentationHook: true
   }
 });
 

--- a/src/app/(navigation)/home/_api/getAuctionRecommends.ts
+++ b/src/app/(navigation)/home/_api/getAuctionRecommends.ts
@@ -102,7 +102,7 @@ export async function getSortedCategory(): Promise<RecommendAuctionsResponse | n
     if (res === null) {
       return null;
     }
-    return res.json();
+    return await res.json();
   } catch (error) {
     console.error("로그인이 되어있지 않아 카테고리별 추천은 제외됩니다.");
   }

--- a/src/app/(navigation)/home/_component/MainContentSection/SearchHeaderBarSection.tsx
+++ b/src/app/(navigation)/home/_component/MainContentSection/SearchHeaderBarSection.tsx
@@ -1,0 +1,47 @@
+"use client";
+import Link from "next/link";
+
+import Icon from "@/app/_component/common/Icon";
+import Modal from "@/app/_component/common/Modal";
+import Notification from "@/app/_component/notification";
+import useModalState from "@/app/_hooks/useModalState";
+
+interface SearchHeaderBarSectionProps {
+  userInform: any;
+  isUserInformFetchLoading: boolean;
+}
+
+const SearchHeaderBarSection = ({
+  userInform,
+  isUserInformFetchLoading
+}: SearchHeaderBarSectionProps) => {
+  const { open, close, isOpen } = useModalState();
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <Link href="/search">
+        <Icon
+          id="search"
+          fill="black"
+        />
+      </Link>
+      {userInform && isUserInformFetchLoading && (
+        <>
+          <button onClick={open}>
+            <Icon id="bell-fill" />
+          </button>
+          <Modal
+            modalType="fullScreen"
+            isOpen={isOpen}
+            close={close}
+            animate="slide"
+            className="dark:bg-black">
+            <Notification close={close} />
+          </Modal>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SearchHeaderBarSection;

--- a/src/app/(navigation)/home/_component/MainContentSection/index.tsx
+++ b/src/app/(navigation)/home/_component/MainContentSection/index.tsx
@@ -1,18 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import { Suspense, useEffect, useState } from "react";
 
 import Header from "@/app/_component/common/Header";
-import Icon from "@/app/_component/common/Icon";
-import Modal from "@/app/_component/common/Modal";
-import Notification from "@/app/_component/notification";
-import useModalState from "@/app/_hooks/useModalState";
 
 import useUserInformation from "../../_hooks/queries/useGetUserInformation";
 import RegionSelect from "../RegionSelect";
 import AuctionListSection from "./AuctionListSection";
 import MainSectionLoading from "./MainSectionLoading";
+import SearchHeaderBarSection from "./SearchHeaderBarSection";
 
 export interface AddressState {
   si: string | null;
@@ -27,8 +23,8 @@ const MainContentSection = () => {
     gu: "",
     dong: ""
   });
-  const { open, close, isOpen } = useModalState();
-  const { data: userInform, isLoading } = useUserInformation();
+  const { data: userInform, isLoading: isUserInformFetchLoading } =
+    useUserInformation();
 
   useEffect(() => {
     const updateAddress = (region: string): AddressState => {
@@ -52,32 +48,6 @@ const MainContentSection = () => {
     setAddress(updateAddress(currentRegion));
   }, [currentRegion]);
 
-  const HeaderRightSection = (
-    <div className="flex items-center justify-end gap-2">
-      <Link href="/search">
-        <Icon
-          id="search"
-          fill="black"
-        />
-      </Link>
-      {userInform && isLoading && (
-        <>
-          <button onClick={open}>
-            <Icon id="bell-fill" />
-          </button>
-          <Modal
-            modalType="fullScreen"
-            isOpen={isOpen}
-            close={close}
-            animate="slide"
-            className="dark:bg-black">
-            <Notification close={close} />
-          </Modal>
-        </>
-      )}
-    </div>
-  );
-
   return (
     <>
       <header>
@@ -91,7 +61,12 @@ const MainContentSection = () => {
               setState={setCurrentRegion}
             />
           }
-          right={HeaderRightSection}
+          right={
+            <SearchHeaderBarSection
+              isUserInformFetchLoading={isUserInformFetchLoading}
+              userInform={userInform}
+            />
+          }
         />
       </header>
       <Suspense fallback={<MainSectionLoading />}>

--- a/src/app/(navigation)/home/_component/MainContentSection/index.tsx
+++ b/src/app/(navigation)/home/_component/MainContentSection/index.tsx
@@ -8,8 +8,8 @@ import Icon from "@/app/_component/common/Icon";
 import Modal from "@/app/_component/common/Modal";
 import Notification from "@/app/_component/notification";
 import useModalState from "@/app/_hooks/useModalState";
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
+import useUserInformation from "../../_hooks/queries/useGetUserInformation";
 import RegionSelect from "../RegionSelect";
 import AuctionListSection from "./AuctionListSection";
 import MainSectionLoading from "./MainSectionLoading";
@@ -20,19 +20,7 @@ export interface AddressState {
   dong: string | null;
 }
 
-interface MainContentSectionProps {
-  userSi: string;
-  userGu: string;
-  userDong: string;
-  user: CheckLoginUserResponse | null;
-}
-
-const MainContentSection = ({
-  userSi,
-  userGu,
-  userDong,
-  user
-}: MainContentSectionProps) => {
+const MainContentSection = () => {
   const [currentRegion, setCurrentRegion] = useState("전국");
   const [address, setAddress] = useState<AddressState>({
     si: "",
@@ -40,7 +28,8 @@ const MainContentSection = ({
     dong: ""
   });
   const { open, close, isOpen } = useModalState();
-
+  const { data: user } = useUserInformation();
+  
   useEffect(() => {
     const updateAddress = (region: string): AddressState => {
       if (region === "전국") {

--- a/src/app/(navigation)/home/_component/MainContentSection/index.tsx
+++ b/src/app/(navigation)/home/_component/MainContentSection/index.tsx
@@ -28,8 +28,8 @@ const MainContentSection = () => {
     dong: ""
   });
   const { open, close, isOpen } = useModalState();
-  const { data: user } = useUserInformation();
-  
+  const { data: userInform, isLoading } = useUserInformation();
+
   useEffect(() => {
     const updateAddress = (region: string): AddressState => {
       if (region === "전국") {
@@ -60,8 +60,7 @@ const MainContentSection = () => {
           fill="black"
         />
       </Link>
-
-      {user && (
+      {userInform && isLoading && (
         <>
           <button onClick={open}>
             <Icon id="bell-fill" />
@@ -85,9 +84,9 @@ const MainContentSection = () => {
         <Header
           left={
             <RegionSelect
-              si={userSi}
-              gu={userGu}
-              dong={userDong}
+              si={userInform?.address.si ? userInform.address.si : ""}
+              gu={userInform?.address.gu ? userInform.address.gu : ""}
+              dong={userInform?.address.dong ? userInform.address.dong : ""}
               currentRegion={currentRegion}
               setState={setCurrentRegion}
             />

--- a/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
+++ b/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
@@ -1,9 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { getLoginUserInfo } from "@/app/_api/user";
 
 const useUserInformation = () => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ["userInformation"],
     queryFn: getLoginUserInfo
   });

--- a/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
+++ b/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
@@ -1,9 +1,9 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 import { getLoginUserInfo } from "@/app/_api/user";
 
 const useUserInformation = () => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ["userInformation"],
     queryFn: getLoginUserInfo
   });

--- a/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
+++ b/src/app/(navigation)/home/_hooks/queries/useGetUserInformation.ts
@@ -1,0 +1,12 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { getLoginUserInfo } from "@/app/_api/user";
+
+const useUserInformation = () => {
+  return useSuspenseQuery({
+    queryKey: ["userInformation"],
+    queryFn: getLoginUserInfo
+  });
+};
+
+export default useUserInformation;

--- a/src/app/(navigation)/home/page.tsx
+++ b/src/app/(navigation)/home/page.tsx
@@ -4,9 +4,6 @@ import {
   QueryClient
 } from "@tanstack/react-query";
 
-import { getLoginUserInfo } from "@/app/_api/user";
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
-
 import {
   getSortedBids,
   getSortedBookMarks,
@@ -19,28 +16,22 @@ import MainContentSection from "./_component/MainContentSection";
 const MainPage = async () => {
   const queryClient = new QueryClient();
 
-  await queryClient.prefetchQuery({
-    queryKey: ["user"],
-    queryFn: getLoginUserInfo
-  });
-
-  const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
-  const address = user ? user.address : { si: "", gu: "", dong: "" };
+  const address = { si: "", gu: "", dong: "" };
 
   await queryClient.prefetchQuery({
-    queryKey: ["auction", "bookmark", address],
+    queryKey: ["auction", "bookmark"],
     queryFn: () => getSortedBookMarks({ address })
   });
   await queryClient.prefetchQuery({
-    queryKey: ["auction", "recently", address],
+    queryKey: ["auction", "recently"],
     queryFn: () => getSortedRecentlyCreated({ address })
   });
   await queryClient.prefetchQuery({
-    queryKey: ["auction", "deadline", address],
+    queryKey: ["auction", "deadline"],
     queryFn: () => getSortedDeadLine({ address })
   });
   await queryClient.prefetchQuery({
-    queryKey: ["auction", "bids", address],
+    queryKey: ["auction", "bids"],
     queryFn: () => getSortedBids({ address })
   });
   await queryClient.prefetchQuery({
@@ -52,12 +43,7 @@ const MainPage = async () => {
   return (
     <section className="px-4">
       <HydrationBoundary state={dehydratedState}>
-        <MainContentSection
-          userSi={address.si}
-          userGu={address.gu}
-          userDong={address.dong}
-          user={user ? user : null}
-        />
+        <MainContentSection />
       </HydrationBoundary>
     </section>
   );

--- a/src/app/(navigation)/layout.tsx
+++ b/src/app/(navigation)/layout.tsx
@@ -1,8 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
-
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
-
-import { getLoginUserInfo } from "../_api/user";
 import Navigation from "../_component/common/Navigation";
 
 export default async function HomeLayout({
@@ -10,20 +5,12 @@ export default async function HomeLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ["user"],
-    queryFn: getLoginUserInfo
-  });
-
-  const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
 
   return (
     <main>
       {children}
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation user={user} />
+        <Navigation />
       </nav>
     </main>
   );

--- a/src/app/(userpage)/layout.tsx
+++ b/src/app/(userpage)/layout.tsx
@@ -23,7 +23,7 @@ export default async function UserPageLayout({
     <section>
       <div className="px-2">{children}</div>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation user={user} />
+        <Navigation />
       </nav>
     </section>
   );

--- a/src/app/(userpage)/layout.tsx
+++ b/src/app/(userpage)/layout.tsx
@@ -1,8 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
-
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
-
-import { getLoginUserInfo } from "../_api/user";
 import Navigation from "../_component/common/Navigation";
 
 export default async function UserPageLayout({
@@ -10,15 +5,6 @@ export default async function UserPageLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ["user"],
-    queryFn: getLoginUserInfo
-  });
-
-  const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
-
   return (
     <section>
       <div className="px-2">{children}</div>

--- a/src/app/_api/user.ts
+++ b/src/app/_api/user.ts
@@ -6,7 +6,7 @@ export const getLoginUserInfo =
     const isTokenValid = authCheck();
     try {
       if (!isTokenValid) return null;
-
+      console.log(isTokenValid);
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
         {
@@ -15,7 +15,7 @@ export const getLoginUserInfo =
           }
         }
       );
-      return res.json();
+      return await res.json();
     } catch (error: any) {
       if (error.status !== 401) {
         throw new Error(error.message);

--- a/src/app/_api/user.ts
+++ b/src/app/_api/user.ts
@@ -6,7 +6,6 @@ export const getLoginUserInfo =
     const isTokenValid = authCheck();
     try {
       if (!isTokenValid) return null;
-      console.log(isTokenValid);
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/users`,
         {

--- a/src/app/_api/user.ts
+++ b/src/app/_api/user.ts
@@ -21,5 +21,6 @@ export const getLoginUserInfo =
         throw new Error(error.message);
       }
     }
+
     return null;
   };

--- a/src/app/_component/common/Navigation/index.tsx
+++ b/src/app/_component/common/Navigation/index.tsx
@@ -5,21 +5,18 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import useSession from "@/app/_hooks/queries/useSession";
+import useUserInformation from "@/app/(navigation)/home/_hooks/queries/useGetUserInformation";
 import { cn } from "@/utils/function/cn";
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
 
 import Icon from "../Icon";
 import ThemeButton from "../ThemeButton";
 import LoginLink from "./LoginLink";
 
-interface NavigationProps {
-  user: CheckLoginUserResponse | undefined;
-}
-
-const Navigation = ({ user }: NavigationProps) => {
+const Navigation = () => {
   const pathname = usePathname();
   const { data: session } = useSession();
-  const userData = user || session;
+  const { data: userInform } = useUserInformation();
+  const userData = userInform || session;
 
   return (
     <div className="flex justify-around items-center h-[56px] border-t border-l border-r  bg-white dark:bg-black border-[#96E4FF] rounded-t-2xl">

--- a/src/app/bookmark/layout.tsx
+++ b/src/app/bookmark/layout.tsx
@@ -1,6 +1,3 @@
-import { QueryClient } from "@tanstack/react-query";
-
-import { getLoginUserInfo } from "../_api/user";
 import Navigation from "../_component/common/Navigation";
 import BookmarkPageHeader from "./_component/header";
 
@@ -9,13 +6,6 @@ export default async function UserPageLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ["user"],
-    queryFn: getLoginUserInfo
-  });
-
   return (
     <section>
       <div className="w-[95%] mx-auto">
@@ -26,5 +16,5 @@ export default async function UserPageLayout({
         <Navigation />
       </nav>
     </section>
-  );
+  );  
 }

--- a/src/app/bookmark/layout.tsx
+++ b/src/app/bookmark/layout.tsx
@@ -1,7 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
 
-import { CheckLoginUserResponse } from "@/utils/types/user/users";
-
 import { getLoginUserInfo } from "../_api/user";
 import Navigation from "../_component/common/Navigation";
 import BookmarkPageHeader from "./_component/header";
@@ -18,8 +16,6 @@ export default async function UserPageLayout({
     queryFn: getLoginUserInfo
   });
 
-  const user = queryClient.getQueryData<CheckLoginUserResponse>(["user"]);
-
   return (
     <section>
       <div className="w-[95%] mx-auto">
@@ -27,7 +23,7 @@ export default async function UserPageLayout({
         {children}
       </div>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation user={user} />
+        <Navigation />
       </nav>
     </section>
   );

--- a/src/app/chatrooms/page.tsx
+++ b/src/app/chatrooms/page.tsx
@@ -35,7 +35,7 @@ const ChatRooms = () => {
         </Suspense>
       </section>
       <nav className="fixed w-full bottom-0 max-w-[360px] h-[56px]">
-        <Navigation user={user} />
+        <Navigation />
       </nav>
     </>
   );

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,13 +1,15 @@
 export async function register() {
-  console.log(
-    "[instrumentation] server.listen()...",
-    process.env.NEXT_RUNTIME,
-    typeof window
-  );
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    const server = (await import("@/utils/mocks/server")).default;
-    server.listen({
-      onUnhandledRequest: "bypass"
-    });
+  if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
+    console.log(
+      "[instrumentation] server.listen()...",
+      process.env.NEXT_RUNTIME,
+      typeof window
+    );
+    if (process.env.NEXT_RUNTIME === "nodejs") {
+      const server = (await import("@/utils/mocks/server")).default;
+      server.listen({
+        onUnhandledRequest: "bypass"
+      });
+    }
   }
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,13 @@
+export async function register() {
+  console.log(
+    "[instrumentation] server.listen()...",
+    process.env.NEXT_RUNTIME,
+    typeof window
+  );
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const server = (await import("@/utils/mocks/server")).default;
+    server.listen({
+      onUnhandledRequest: "bypass"
+    });
+  }
+}

--- a/src/utils/MSWComponent.tsx
+++ b/src/utils/MSWComponent.tsx
@@ -5,6 +5,7 @@ export const MSWComponent = () => {
   useEffect(() => {
     if (typeof window !== "undefined") {
       if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
+        console.log(process.env.NEXT_PUBLIC_API_MOCKING);
         const init = async () => {
           const { worker } = await import("@/utils/mocks/browser");
           worker.start();

--- a/src/utils/mocks/server.ts
+++ b/src/utils/mocks/server.ts
@@ -1,0 +1,6 @@
+import { setupServer } from "msw/node";
+
+import { handlers } from "./handlers";
+
+const server = setupServer(...handlers);
+export default server;


### PR DESCRIPTION
## 📑 구현 사항
### 사용자 정보 fetch들의 관련 타이밍 서버 환경에서 -> 클라이언트 으로 변경
쿠키 토큰을 통해 사용자 정보를 불러오는`getLoginUserInfo` 메서드가 여러곳에서 prefetch 되고 있는 부분을 suspenseQuery 사용으로 변경하였습니다.

사유는 #297 에 작성되어 있습니다.

#### 해당 컴포넌트
- [x] 메인 홈 컴포넌트
- [x] 네비게이션 컴포넌트 
- [x] 유저 페이지 컴포넌트
- [x] 북마크 컴포넌트
- [x] 채팅 페이지

<br/>

### MSW 서버 모킹 환경 추가하였습니다.
현재 prefetch 방식으로 호출되고 있는 api들이 꽤나 있지만, 이전까지 MSW는 클라이언트 환경에서만 실행되었기 때문에, prefetch를 사용하는 api들은 계속 fetch Error을 발생시켜왔습니다. 
그래서 이 문제들을 해결하기 위해 Nextjs에서 지원하는 `instrumentation`에서 register 함수를 사용하여 서버 환경에서도 mocking api들이 작동 할 수 있도록 하였습니다. 

#### `instrumentation` 이란?
instrumentation 기능은 애플리케이션에 통합 가시성 도구를 사용하여 성능 및 동작을 추적하고 프로덕션 환경에서 문제를 디버그할 수 있도록 한다고 하네요?
그중 register 함수는 Next.js 서버 인스턴스가 시작될 때 한 번 호출될 때 실행되는 함수로, 서버에서 실행할 기능이 있다면 register함수에 넣으면 되는데, 여기에 msw 실행 함수를 넣어 이 문제를 해결 했습니다. 

[공식문서](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation)


### 리펙토링
#### 컴포넌트내에 또 다른 컴포넌트가 선언되어있는것을 발견하여 외부로 분리하였습니다.
(home/_component/MainContentSection컴포넌트 내부의 HeaderRightSection)  -> (home/_component/searchHeaderbarSection) 

사유 - 컴포넌트 내부에 컴포넌트가 선언되어있다면 컴포넌트가 렌더링될 때마다, 내부에 선언된 컴포넌트가 새롭게 정의되기 때문에, React는 매 렌더링 시마다 새로운 컴포넌트를 생성한다고 인식하여 불필요한 렌더링을 유발한다고 합니다!

## 🚨 관련 이슈

close #297 

