### PR TITLE
Fix : 경매 물품 페이지에 필터 기능에서 배송, 직거래 필터 적용 안되는 버그 수정 

### DIFF
--- a/src/app/search/[searchString]/_component/searchFilter/TradeMethodSelection.tsx
+++ b/src/app/search/[searchString]/_component/searchFilter/TradeMethodSelection.tsx
@@ -28,8 +28,8 @@ export default function TradeMethodSelection() {
         <label>
           <input
             type="radio"
-            id="direct"
-            value="직거래"
+            id="delivery"
+            value="택배"
             className="peer hidden"
             {...register("tradeMethod")}
           />

--- a/src/app/search/[searchString]/_component/searchFilter/index.tsx
+++ b/src/app/search/[searchString]/_component/searchFilter/index.tsx
@@ -27,7 +27,7 @@ const SearchFilterModal = ({
     mode: "all",
     defaultValues: {
       minPrice: 0,
-      maxPrice: 0
+      maxPrice: 999999
     }
   });
 


### PR DESCRIPTION
## 📑 구현 사항

- [x] 경매 물품 페이지에 필터 기능에서 배송, 직거래 필터 적용 안되는 버그 수정 


## 🚧 특이 사항
- 검색 필터 항목 중에 하나인 물품 최대 가격의 기본 값이 0원으로 설정되어있어서, 해당 input에 미 입력 시 무조건 0으로 설정되기 때문에 최소,최대 값 상관없이 필터링 확인 할 수 있도록 해당 기본 값을 최대치로 수정했습니다.
- 검색 필터에서 "택배" 선택 버튼이 올바르지 않은 value가 들어가 있어서 수정했습니다. (기존 입력 값 "직거래" -> "택배") 로 수정

## 🚨 관련 이슈

close #302
